### PR TITLE
refactor(react): support multiple stores in QuantaProvider and useStore hook

### DIFF
--- a/packages/core/src/core/create-reactive.ts
+++ b/packages/core/src/core/create-reactive.ts
@@ -1,6 +1,6 @@
 import { track, trigger } from './effect';
 
-// This method handles Map and Set types specifically
+// handles Map and Set types specifically
 function createReactiveCollection(target: Map<any, any> | Set<any>) {
     return new Proxy(target, {
         get(target, prop: string | symbol) {
@@ -49,7 +49,7 @@ function createReactiveCollection(target: Map<any, any> | Set<any>) {
     });
 }
 
-// Main createReactive function to handle all data types
+// createReactive function to handle all data types
 export function createReactive(target: any) {
     if (target instanceof Map || target instanceof Set) {
         return createReactiveCollection(target); // Handle Map/Set specially

--- a/packages/core/src/core/effect.ts
+++ b/packages/core/src/core/effect.ts
@@ -40,7 +40,7 @@ export function trigger(target: object, prop: string | symbol) {
     }
 }
 
-// Other existing methods remain unchanged
+// Track dependencies for reactive properties
 export function track(target: object, prop: string | symbol) {
     let depsMap = targetMap.get(target);
     if (!depsMap) {
@@ -56,6 +56,7 @@ export function track(target: object, prop: string | symbol) {
     }
 }
 
+// Reactive effect to handle reactivity
 export function reactiveEffect(effect: Function) {
     const wrappedEffect = () => {
         if (effectStack.includes(effect)) {

--- a/packages/react/readme.md
+++ b/packages/react/readme.md
@@ -32,37 +32,41 @@ import { createStore, QuantaProvider, useStore } from '@quantajs/react';
 
 // Create store
 const counterStore = createStore('counter', {
-  state: () => ({ count: 0 }),
-  getters: {
-    doubleCount: (state) => state.count * 2
-  },
-  actions: {
-    increment() { this.count++; },
-    decrement() { this.count--; }
-  }
+    state: () => ({ count: 0 }),
+    getters: {
+        doubleCount: (state) => state.count * 2,
+    },
+    actions: {
+        increment() {
+            this.count++;
+        },
+        decrement() {
+            this.count--;
+        },
+    },
 });
 
 // Component
 function Counter() {
-  const store = useStore();
-  
-  return (
-    <div>
-      <p>Count: {store.count}</p>
-      <p>Double: {store.doubleCount}</p>
-      <button onClick={() => store.increment()}>+</button>
-      <button onClick={() => store.decrement()}>-</button>
-    </div>
-  );
+    const store = useStore();
+
+    return (
+        <div>
+            <p>Count: {store.count}</p>
+            <p>Double: {store.doubleCount}</p>
+            <button onClick={() => store.increment()}>+</button>
+            <button onClick={() => store.decrement()}>-</button>
+        </div>
+    );
 }
 
 // App
 function App() {
-  return (
-    <QuantaProvider store={counterStore}>
-      <Counter />
-    </QuantaProvider>
-  );
+    return (
+        <QuantaProvider store={counterStore}>
+            <Counter />
+        </QuantaProvider>
+    );
 }
 ```
 
@@ -72,10 +76,10 @@ function App() {
 import { useQuantaStore } from '@quantajs/react';
 
 function CounterDisplay() {
-  // Only re-render when count changes
-  const count = useQuantaStore(counterStore, store => store.count);
-  
-  return <p>Count: {count}</p>;
+    // Only re-render when count changes
+    const count = useQuantaStore(counterStore, (store) => store.count);
+
+    return <p>Count: {count}</p>;
 }
 ```
 
@@ -85,39 +89,42 @@ function CounterDisplay() {
 import { useCreateStore } from '@quantajs/react';
 
 function TodoComponent() {
-  const todoStore = useCreateStore(
-    'todos',
-    () => ({ todos: [] }),
-    undefined,
-    {
-      addTodo(text: string) {
-        this.todos.push({ id: Date.now(), text, done: false });
-      }
-    }
-  );
+    const todoStore = useCreateStore(
+        'todos',
+        () => ({ todos: [] }),
+        undefined,
+        {
+            addTodo(text: string) {
+                this.todos.push({ id: Date.now(), text, done: false });
+            },
+        },
+    );
 
-  return (
-    <div>
-      <button onClick={() => todoStore.addTodo('New task')}>
-        Add Todo
-      </button>
-      <p>Todos: {todoStore.todos.length}</p>
-    </div>
-  );
+    return (
+        <div>
+            <button onClick={() => todoStore.addTodo('New task')}>
+                Add Todo
+            </button>
+            <p>Todos: {todoStore.todos.length}</p>
+        </div>
+    );
 }
 ```
 
 ## 🔧 API
 
 ### Hooks
+
 - `useQuantaStore(store, selector?)` - Subscribe to store with optional selector
 - `useStore(selector?)` - Access store from QuantaProvider context
 - `useCreateStore(name, state, getters?, actions?)` - Create component-scoped store
 
 ### Components
+
 - `<QuantaProvider store={store}>` - Provide store to child components
 
 ### Core Features
+
 - `createStore`, `reactive`, `computed`, `watch` - Re-exported from @quantajs/core
 
 ## 📜 License

--- a/packages/react/src/components/QuantaProvider.tsx
+++ b/packages/react/src/components/QuantaProvider.tsx
@@ -3,18 +3,18 @@ import type { StoreInstance } from '@quantajs/core';
 import { QuantaContext } from '../context/QuantaContext';
 
 export interface QuantaProviderProps {
-    store: StoreInstance<any, any, any>;
+    stores: { [key: string]: StoreInstance<any, any, any> };
     children: ReactNode;
 }
 
 /**
  * Provider component that makes a QuantaJS store available to all child components
- * @param store - The QuantaJS store instance to provide
- * @param children - Child components that can access the store
+ * @param stores - The QuantaJS stores instances to provide
+ * @param children - Child components that can access the stores
  */
-export function QuantaProvider({ store, children }: QuantaProviderProps) {
+export function QuantaProvider({ stores, children }: QuantaProviderProps) {
     return (
-        <QuantaContext.Provider value={{ store }}>
+        <QuantaContext.Provider value={{ stores }}>
             {children}
         </QuantaContext.Provider>
     );

--- a/packages/react/src/context/QuantaContext.tsx
+++ b/packages/react/src/context/QuantaContext.tsx
@@ -2,10 +2,10 @@ import { createContext, useContext } from 'react';
 import type { StoreInstance } from '@quantajs/core';
 
 export interface QuantaContextValue {
-    store: StoreInstance<any, any, any>;
+    stores: { [name: string]: StoreInstance<any, any, any> };
 }
 
-export const QuantaContext = createContext<QuantaContextValue | null>(null);
+export const QuantaContext = createContext<QuantaContextValue>({ stores: {} });
 
 /**
  * Hook to access the QuantaJS store from the context

--- a/packages/react/src/hooks/useStore.ts
+++ b/packages/react/src/hooks/useStore.ts
@@ -4,14 +4,21 @@ import type { StoreInstance } from '@quantajs/core';
 
 /**
  * Hook to access and subscribe to the QuantaJS store from context
+ * @param name - The name of the store to access
  * @param selector - Optional selector function to pick specific parts of the store
  * @returns The store instance or selected value that updates reactively
  */
 export function useStore<T = any>(
+    name: string,
     selector?: (store: StoreInstance<any, any, any>) => T,
 ): T extends undefined ? StoreInstance<any, any, any> : T {
-    const { store } = useQuantaContext();
-
+    const { stores } = useQuantaContext();
+    const store = stores[name];
+    if (!store) {
+        throw new Error(
+            `Store with name "${name}" does not exist in the context.`,
+        );
+    }
     if (selector) {
         return useQuantaStore(store, selector) as T extends undefined
             ? StoreInstance<any, any, any>


### PR DESCRIPTION
- Updated QuantaProvider to accept a  object instead of a single
- Modified QuantaContext to expose all stores by name
- Updated  hook to require store name and handle missing stores