### PR TITLE
Add in-repo verification examples (vanilla, react-vite, next.js)

### DIFF
--- a/.changeset/quanta-2-1-0.md
+++ b/.changeset/quanta-2-1-0.md
@@ -68,6 +68,15 @@ reading.
 - Diagnostics are `__DEV__`-gated and emitted once at the boundary rather than
   restacked at every layer — one error used to produce seven log lines.
 - `batchEffects()` returns its callback's value.
+- **A `computed` read through `store.subscribe()` could be one write stale.**
+  Found by the new `examples/vanilla` verification app. A store's coarse
+  "something changed" notifier and a getter's cache-invalidation are separate
+  effects triggered by the same write, both deferred to the same
+  `batchEffects` flush; the notifier happened to flush first, so it could read
+  the getter before its cache had been invalidated — visible every other
+  mutation once a getter had been read at least once. Getter invalidation
+  (`EffectOptions.eager`) now runs immediately instead of waiting its turn in
+  the batch queue.
 - **New:** `effect`, `effectScope`, `untrack`, `nextTick`, `toRaw`, `markRaw`,
   `readonly`, `shallowReactive`, `shallowReadonly`, `isProxy`, `isReadonly`.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,3 +92,38 @@ jobs:
 
       - name: 📊 Run benchmarks
         run: pnpm bench
+
+  examples:
+    name: Examples (in-repo verification)
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v4
+
+      - name: 📦 Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: 🌐 Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      # examples/* consume the packages via workspace:*, resolved through
+      # each package's real `main`/`module`/`exports` fields — this installs
+      # every example's dependencies (React, Vite, Next.js) too, which is why
+      # this job is separate from lint/test rather than folded into them.
+      - name: 📦 Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: 🏗️ Build packages
+        run: pnpm build
+
+      - name: 🏗️ Build examples
+        run: pnpm examples:build
+
+      - name: ✅ Verify examples
+        run: pnpm examples:verify

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ dist
 dist-ssr
 *.local
 
+# Next.js (examples/nextjs-app)
+.next
+next-env.d.ts
+
 # Test coverage
 coverage
 tsconfig.tsbuildinfo

--- a/examples/nextjs-app/README.md
+++ b/examples/nextjs-app/README.md
@@ -1,0 +1,48 @@
+# QuantaJS — Next.js App Router example
+
+The one scenario nothing else in this repo validates: SSR through a real
+bundler, not `happy-dom`.
+
+## Run it
+
+```sh
+pnpm install
+pnpm --filter "./packages/**" build
+pnpm --filter example-nextjs-app dev
+```
+
+## The round trip
+
+1. **`app/page.tsx`** (Server Component) creates a container **per request**
+   with `createContainer()` — never the ambient one, which is shared across
+   every request this Node process serves. It resolves the store, sets some
+   state (standing in for a DB/session read), then calls
+   `container.dehydrate()` and disposes the container.
+2. The resulting snapshot is passed as a prop into **`app/providers.tsx`**
+   (`'use client'`), which hands it to `<QuantaProvider snapshot={...}>`.
+   The provider creates a fresh container on the client and applies the
+   snapshot synchronously during the first render — before children mount —
+   so the client's first paint matches the server's HTML.
+3. **`Counter`**, also in `providers.tsx`, reads and mutates the store with
+   `useQuanta` like any client-side store — the fact that its initial value
+   came from the server is invisible to it.
+
+## Verifying the build
+
+```sh
+pnpm --filter example-nextjs-app build
+pnpm --filter example-nextjs-app verify
+```
+
+`next build` succeeding is itself most of the test: it's the only place in
+this repo that runs the SSR/hydration code through Next's real App Router
+bundler rather than `happy-dom`. `verify-build.mjs` additionally checks
+`.next/server` for a client-reference-manifest, confirming Next actually
+recognized the `'use client'` boundary in `providers.tsx` rather than
+silently rendering it as a Server Component.
+
+A `renderToString`/`hydrateRoot` test covering the same dehydrate/hydrate
+round trip — without a Next.js dependency — lives in
+`packages/react/src/__tests__/ssr.test.tsx` for fast day-to-day feedback;
+this example exists for what that test structurally can't reach: the RSC
+boundary and real bundler behavior.

--- a/examples/nextjs-app/app/layout.tsx
+++ b/examples/nextjs-app/app/layout.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from 'react';
+
+export const metadata = {
+    title: 'QuantaJS + Next.js App Router',
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+    return (
+        <html lang="en">
+            <body>{children}</body>
+        </html>
+    );
+}

--- a/examples/nextjs-app/app/page.tsx
+++ b/examples/nextjs-app/app/page.tsx
@@ -1,0 +1,30 @@
+import { createContainer } from '@quantajs/core';
+import { useCounterStore } from '../lib/store';
+import { Providers, Counter } from './providers';
+
+/**
+ * A Server Component. **Never** resolve a store against the ambient
+ * container here — this module runs in one Node process shared across every
+ * request, so the ambient container would leak one visitor's state into
+ * another's. A container created per request, right here in the request
+ * path, is what keeps them isolated.
+ */
+export default function Page() {
+    const container = createContainer();
+    const counter = useCounterStore(container);
+
+    // Stand-in for "load from a database / session" — anything that varies
+    // per request.
+    counter.count = 7;
+
+    const snapshot = container.dehydrate();
+    // The snapshot above is a plain, already-copied object — the container
+    // itself is done being useful the moment it's taken.
+    container.dispose();
+
+    return (
+        <Providers snapshot={snapshot}>
+            <Counter />
+        </Providers>
+    );
+}

--- a/examples/nextjs-app/app/providers.tsx
+++ b/examples/nextjs-app/app/providers.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import type { ContainerSnapshot } from '@quantajs/core';
+import { QuantaProvider, useQuanta } from '@quantajs/react';
+import { useCounterStore } from '../lib/store';
+
+/**
+ * The client boundary. `<QuantaProvider>` creates its own container on the
+ * client (none is passed here) and applies `snapshot` — produced by
+ * `container.dehydrate()` on the server — before the first paint, so the
+ * client's first render matches the server's HTML instead of flashing
+ * default state and correcting itself.
+ */
+export function Providers({
+    snapshot,
+    children,
+}: {
+    snapshot: ContainerSnapshot;
+    children: ReactNode;
+}) {
+    return <QuantaProvider snapshot={snapshot}>{children}</QuantaProvider>;
+}
+
+/** A Client Component reading and mutating the store — proves the store
+ * built with `state`/`getters`/`actions` on the server is live on the
+ * client, not just inert HTML. */
+export function Counter() {
+    const counter = useQuanta(useCounterStore);
+    return (
+        <p>
+            server sent count = {counter.count} (doubled: {counter.doubled}) —{' '}
+            <button onClick={() => counter.increment()}>increment</button>
+        </p>
+    );
+}

--- a/examples/nextjs-app/lib/store.ts
+++ b/examples/nextjs-app/lib/store.ts
@@ -1,0 +1,18 @@
+import { defineStore } from '@quantajs/core';
+
+/**
+ * Safe to declare at module scope — a definition holds no state, so
+ * importing it does nothing per-request. State only exists once resolved
+ * against a container, which `app/page.tsx` does per request.
+ */
+export const useCounterStore = defineStore('counter', {
+    state: () => ({ count: 0 }),
+    getters: {
+        doubled: (s) => s.count * 2,
+    },
+    actions: {
+        increment() {
+            this.count++;
+        },
+    },
+});

--- a/examples/nextjs-app/next.config.mjs
+++ b/examples/nextjs-app/next.config.mjs
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+export default nextConfig;

--- a/examples/nextjs-app/package.json
+++ b/examples/nextjs-app/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "example-nextjs-app",
+    "private": true,
+    "version": "0.0.0",
+    "description": "Next.js App Router: a per-request container, dehydrate/hydrate through a 'use client' boundary, and a build check that the client boundary survives the real bundler.",
+    "scripts": {
+        "dev": "next dev",
+        "build": "next build",
+        "verify": "node verify-build.mjs"
+    },
+    "dependencies": {
+        "@quantajs/core": "workspace:*",
+        "@quantajs/react": "workspace:*",
+        "next": "^16.3.1",
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4"
+    },
+    "devDependencies": {
+        "@types/node": "^25.3.5",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.4",
+        "typescript": "^6.0.2"
+    }
+}

--- a/examples/nextjs-app/tsconfig.json
+++ b/examples/nextjs-app/tsconfig.json
@@ -1,0 +1,36 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/examples/nextjs-app/verify-build.mjs
+++ b/examples/nextjs-app/verify-build.mjs
@@ -1,0 +1,49 @@
+// `next build` succeeding at all is most of the value here — nothing else in
+// this repo builds a real Next.js App Router app, so it's the only thing
+// that can catch a `'use client'` banner getting dropped or mangled by
+// @quantajs/react's build, or an SSR/hydration path that only worked under
+// happy-dom.
+//
+// On top of that, confirm Next actually recognized a client/server split:
+// if `app/providers.tsx` were ever rendered as a Server Component (the
+// directive lost), no client-reference-manifest would exist at all.
+import assert from 'node:assert/strict';
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const dir = path.dirname(fileURLToPath(import.meta.url));
+const nextDir = path.join(dir, '.next');
+assert.ok(
+    existsSync(nextDir),
+    '.next build output missing — run `next build` before `verify`',
+);
+
+const serverDir = path.join(nextDir, 'server');
+assert.ok(
+    existsSync(serverDir),
+    '.next/server missing — the App Router server build did not run',
+);
+
+function findFiles(root, predicate, found = []) {
+    for (const entry of readdirSync(root)) {
+        const full = path.join(root, entry);
+        if (statSync(full).isDirectory()) findFiles(full, predicate, found);
+        else if (predicate(entry)) found.push(full);
+    }
+    return found;
+}
+
+const clientReferenceManifests = findFiles(serverDir, (name) =>
+    name.includes('client-reference-manifest'),
+);
+assert.ok(
+    clientReferenceManifests.length > 0,
+    'no client-reference-manifest found in .next/server — Next.js did not see a ' +
+        '"use client" boundary. If @quantajs/react ever drops or mis-banners its ' +
+        '"use client" directive, this is what breaks.',
+);
+
+console.log(
+    `[verify-build] OK — next build succeeded, ${clientReferenceManifests.length} client-reference-manifest file(s) found`,
+);

--- a/examples/react-vite/README.md
+++ b/examples/react-vite/README.md
@@ -1,0 +1,44 @@
+# QuantaJS — React + Vite example
+
+## Run it
+
+```sh
+pnpm install
+pnpm --filter example-react-vite dev
+```
+
+## What's in here
+
+`src/main.tsx` renders under `<StrictMode>` (kept on permanently — it's what
+would have caught a hook that breaks on React's development-only
+mount/unmount/remount cycle) with an **explicit** `createContainer()` passed
+to `<QuantaProvider>`, and `<QuantaDevTools>` mounted alongside the app.
+
+`src/App.tsx` exercises every React hook the package ships:
+
+| Hook | Where |
+|---|---|
+| `useQuanta` | `CartSummary`, `CheckoutButton` — full store, subscribed |
+| `useQuantaValue` | `ItemCount` — a selector, fine-grained subscription |
+| `useQuantaActions` | `AddItemForm`, `TaxTotal` — resolves without subscribing |
+| `useComputed` | `TaxTotal` — a cached derivation |
+| `useWatch` | `CartToast` — a side effect on a watched value |
+| `useLocalStore` | `Wizard` (rendered twice) — container scoped to the component instance |
+
+`CheckoutButton` calls a fake-network async action to drive its `pending`,
+`error` and `abort()` state in a real component, not just a unit test.
+
+## Verifying the build, not just the demo
+
+`verify-build.mjs` runs after `vite build` and inspects `dist/` directly: it
+asserts the lazily-loaded `./Heavy` panel and `@quantajs/devtools` (which
+pulls in Preact) each land in their own chunk, separate from the main entry.
+This is the regression test for `@quantajs/react` accidentally bundling
+Preact into every consumer instead of code-splitting it — a build-shape bug
+no unit test running against `src/` can see.
+
+```sh
+pnpm --filter "./packages/**" build
+pnpm --filter example-react-vite build
+pnpm --filter example-react-vite verify
+```

--- a/examples/react-vite/index.html
+++ b/examples/react-vite/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>QuantaJS — React + Vite example</title>
+    </head>
+    <body>
+        <div id="root"></div>
+        <script type="module" src="/src/main.tsx"></script>
+    </body>
+</html>

--- a/examples/react-vite/package.json
+++ b/examples/react-vite/package.json
@@ -1,0 +1,26 @@
+{
+    "name": "example-react-vite",
+    "private": true,
+    "version": "0.0.0",
+    "type": "module",
+    "description": "React + Vite: StrictMode, every hook, an async action's pending/error/abort, and a build-output check that code-splitting (the lazy panel and QuantaDevTools' Preact chunk) actually happened.",
+    "scripts": {
+        "dev": "vite",
+        "build": "vite build",
+        "verify": "node verify-build.mjs"
+    },
+    "dependencies": {
+        "@quantajs/core": "workspace:*",
+        "@quantajs/devtools": "workspace:*",
+        "@quantajs/react": "workspace:*",
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4"
+    },
+    "devDependencies": {
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.4",
+        "@vitejs/plugin-react": "^6.0.5",
+        "typescript": "^6.0.2",
+        "vite": "^8.0.3"
+    }
+}

--- a/examples/react-vite/src/App.tsx
+++ b/examples/react-vite/src/App.tsx
@@ -1,0 +1,158 @@
+import { Suspense, lazy, useState } from 'react';
+import {
+    useQuanta,
+    useQuantaValue,
+    useQuantaActions,
+    useLocalStore,
+    useComputed,
+    useWatch,
+} from '@quantajs/react';
+import { useCartStore, useWizardStore } from './stores';
+
+const Heavy = lazy(() => import('./Heavy'));
+
+/** `useQuanta`: the whole store, subscribed to every change. */
+function CartSummary() {
+    const cart = useQuanta(useCartStore);
+    return (
+        <ul>
+            {cart.items.map((item) => (
+                <li key={item.id}>
+                    {item.name} — ${item.price}{' '}
+                    <button onClick={() => cart.remove(item.id)}>remove</button>
+                </li>
+            ))}
+        </ul>
+    );
+}
+
+/** `useQuantaValue`: subscribes only to what the selector reads. */
+function ItemCount() {
+    const count = useQuantaValue(useCartStore, (s) => s.items.length);
+    return <p>{count} item(s) in cart</p>;
+}
+
+/**
+ * `useComputed`: a cached derivation, recomputed only when its inputs
+ * change. Resolves the store via `useQuantaActions` (no whole-store
+ * subscription) and lets `useComputed` own the fine-grained one instead —
+ * the store must still come from the nearest provider's container, never
+ * from calling the definition directly, or this would read a *different*
+ * container's cart than the rest of the page.
+ */
+function TaxTotal() {
+    const cart = useQuantaActions(useCartStore);
+    const total = useComputed(cart, (s) => s.total * 1.0825);
+    return <p>total incl. tax: ${total.toFixed(2)}</p>;
+}
+
+/** `useQuantaActions`: resolves the store without subscribing — this
+ * component calls actions but never reads state, so it never re-renders on
+ * a cart change. */
+function AddItemForm() {
+    const cart = useQuantaActions(useCartStore);
+    return (
+        <button onClick={() => cart.add('Widget', 9.99)}>Add a widget — $9.99</button>
+    );
+}
+
+/**
+ * Exercises an async action's `pending` / `error` / `abort()`.
+ *
+ * Reads them through `useQuantaValue` selectors rather than off a
+ * `useQuanta`-resolved store: `pending`/`error` live on a separate reactive
+ * object from the store's own `state`, and `useQuanta`'s whole-store
+ * subscription only wakes on a `state` change. A selector tracks its read
+ * directly, so it reacts to the two independently — reading them off
+ * `useQuanta`'s store here would appear to work only by coincidence,
+ * whenever a state write happens to land near the same tick.
+ */
+function CheckoutButton() {
+    const cart = useQuantaActions(useCartStore);
+    const pending = useQuantaValue(useCartStore, (s) => s.checkout.pending);
+    const error = useQuantaValue(useCartStore, (s) => s.checkout.error);
+    return (
+        <p>
+            <button
+                onClick={() => {
+                    // The action rethrows so a caller can react specially to
+                    // one call; this component doesn't need to, since
+                    // `error` above already reflects it — an unawaited
+                    // rejection with nothing catching it would otherwise
+                    // surface as an unhandled rejection in the console.
+                    cart.checkout().catch(() => {});
+                }}
+                disabled={pending}
+            >
+                {pending ? 'Checking out…' : 'Checkout'}
+            </button>
+            {pending && <button onClick={() => cart.checkout.abort()}>Cancel</button>}
+            {error && <span> error: {error.message}</span>}
+        </p>
+    );
+}
+
+/** `useWatch`: a side effect that runs when the watched value changes. */
+function CartToast() {
+    const cart = useQuanta(useCartStore);
+    const [toast, setToast] = useState<string | null>(null);
+
+    useWatch(
+        cart,
+        (s) => s.items.length,
+        (count) => setToast(count === 0 ? null : `cart has ${count} item(s)`),
+    );
+
+    return toast ? <p className="toast">{toast}</p> : null;
+}
+
+/** `useLocalStore`: a container scoped to this component instance — two
+ * `<Wizard>`s never share a step. */
+function Wizard() {
+    const wizard = useLocalStore(useWizardStore);
+    return (
+        <p>
+            step {wizard.step}/3{' '}
+            <button onClick={() => wizard.back()}>back</button>{' '}
+            <button onClick={() => wizard.next()}>next</button>
+        </p>
+    );
+}
+
+export default function App() {
+    const [showHeavy, setShowHeavy] = useState(false);
+
+    return (
+        <main>
+            <h1>QuantaJS + React + Vite</h1>
+
+            <section>
+                <h2>Cart</h2>
+                <AddItemForm />
+                <ItemCount />
+                <CartSummary />
+                <TaxTotal />
+                <CheckoutButton />
+                <CartToast />
+            </section>
+
+            <section>
+                <h2>Two independent wizards (useLocalStore)</h2>
+                <Wizard />
+                <Wizard />
+            </section>
+
+            <section>
+                <h2>Code-split panel</h2>
+                <button onClick={() => setShowHeavy((v) => !v)}>
+                    {showHeavy ? 'Hide' : 'Load'} heavy panel
+                </button>
+                {showHeavy && (
+                    <Suspense fallback={<p>Loading…</p>}>
+                        <Heavy />
+                    </Suspense>
+                )}
+            </section>
+        </main>
+    );
+}

--- a/examples/react-vite/src/Heavy.tsx
+++ b/examples/react-vite/src/Heavy.tsx
@@ -1,0 +1,17 @@
+import { useQuantaValue } from '@quantajs/react';
+import { useCartStore } from './stores';
+
+/**
+ * Loaded through `React.lazy` in `App.tsx`, never statically imported — so
+ * Vite must emit it as its own chunk. Its content doesn't matter; only that
+ * it exists as a separate module for the build-output check to find.
+ */
+export default function Heavy() {
+    const items = useQuantaValue(useCartStore, (s) => s.items);
+    return (
+        <div>
+            <p>Loaded on demand via a lazy, dynamically-imported chunk.</p>
+            <pre>{JSON.stringify(items, null, 2)}</pre>
+        </div>
+    );
+}

--- a/examples/react-vite/src/main.tsx
+++ b/examples/react-vite/src/main.tsx
@@ -1,0 +1,23 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { createContainer } from '@quantajs/core';
+import { QuantaProvider, QuantaDevTools } from '@quantajs/react';
+import App from './App';
+
+// An explicit container, not the ambient one. A client-only app *could* rely
+// on the ambient container, but modeling the explicit form here is the
+// pattern that also works unchanged under SSR, where the ambient container
+// is unsafe (shared across every request).
+const container = createContainer('react-vite-app');
+
+// StrictMode stays on permanently: it double-mounts every component in
+// development, which is exactly what surfaces a hook that leaks state or
+// breaks on remount (that class of bug has hit `useComputed` before).
+createRoot(document.getElementById('root')!).render(
+    <StrictMode>
+        <QuantaProvider container={container}>
+            <App />
+            <QuantaDevTools visible />
+        </QuantaProvider>
+    </StrictMode>,
+);

--- a/examples/react-vite/src/stores.ts
+++ b/examples/react-vite/src/stores.ts
@@ -1,0 +1,55 @@
+import { defineStore } from '@quantajs/core';
+
+export interface CartItem {
+    id: number;
+    name: string;
+    price: number;
+}
+
+let nextId = 1;
+
+export const useCartStore = defineStore('cart', {
+    state: () => ({ items: [] as CartItem[] }),
+    getters: {
+        total: (s) => s.items.reduce((sum, i) => sum + i.price, 0),
+    },
+    actions: {
+        add(name: string, price: number) {
+            this.items.push({ id: nextId++, name, price });
+        },
+        remove(id: number) {
+            this.items = this.items.filter((i) => i.id !== id);
+        },
+        /**
+         * A fake network call, abortable via `this.$signal`. Exercises the
+         * three states every action carries: `pending`, `error` and
+         * `abort()` — in a real component, not just a unit test.
+         */
+        async checkout() {
+            await new Promise<void>((resolve, reject) => {
+                const timer = setTimeout(resolve, 1500);
+                this.$signal?.addEventListener('abort', () => {
+                    clearTimeout(timer);
+                    reject(new Error('Checkout cancelled'));
+                });
+            });
+            this.items = [];
+        },
+    },
+});
+
+/**
+ * Given its own container per component instance by `useLocalStore` — two
+ * `<Wizard>`s on screen at once do not share a step.
+ */
+export const useWizardStore = defineStore('wizard', {
+    state: () => ({ step: 1 }),
+    actions: {
+        next() {
+            this.step = Math.min(3, this.step + 1);
+        },
+        back() {
+            this.step = Math.max(1, this.step - 1);
+        },
+    },
+});

--- a/examples/react-vite/tsconfig.json
+++ b/examples/react-vite/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "compilerOptions": {
+        "target": "ESNext",
+        "useDefineForClassFields": true,
+        "module": "ESNext",
+        "lib": ["ESNext", "DOM"],
+        "moduleResolution": "Bundler",
+        "strict": true,
+        "skipLibCheck": true,
+        "jsx": "react-jsx",
+        "noEmit": true
+    },
+    "include": ["src"]
+}

--- a/examples/react-vite/verify-build.mjs
+++ b/examples/react-vite/verify-build.mjs
@@ -1,0 +1,52 @@
+// Regression test for "the React package bundles Preact into every app that
+// imports it": build this app for real, then inspect the output.
+//
+// `QuantaDevTools` loads `@quantajs/devtools` (and the Preact it depends on)
+// through a dynamic `import()`, and `App.tsx` loads `./Heavy` the same way.
+// If either collapses back into the main entry chunk — e.g. because
+// `@quantajs/react`'s build stops externalizing `preact` — the chunk count
+// below drops and this fails.
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const dir = path.dirname(fileURLToPath(import.meta.url));
+const distDir = path.join(dir, 'dist');
+const assetsDir = path.join(distDir, 'assets');
+
+const indexHtml = readFileSync(path.join(distDir, 'index.html'), 'utf8');
+const entryMatch = indexHtml.match(
+    /<script[^>]*type="module"[^>]*src="\/(assets\/[^"]+\.js)"/,
+);
+assert.ok(entryMatch, 'dist/index.html has no module entry script tag');
+const entryFile = entryMatch[1].split('/').pop();
+
+const jsFiles = readdirSync(assetsDir).filter((f) => f.endsWith('.js'));
+assert.ok(jsFiles.includes(entryFile), `entry chunk ${entryFile} missing from dist/assets`);
+
+const nonEntryChunks = jsFiles.filter((f) => f !== entryFile);
+// One chunk for the lazily-loaded `./Heavy`, one for the dynamically
+// imported `@quantajs/devtools` (which pulls in Preact).
+assert.ok(
+    nonEntryChunks.length >= 2,
+    `expected at least 2 code-split chunks besides the entry, found ${nonEntryChunks.length}: ${jsFiles.join(', ')}`,
+);
+
+const entryContent = readFileSync(path.join(assetsDir, entryFile), 'utf8');
+assert.ok(
+    !/preact/i.test(entryContent),
+    'the main entry chunk contains "preact" — DevTools/Preact leaked into the main bundle instead of staying in its own dynamically-imported chunk',
+);
+
+const preactChunk = nonEntryChunks.find((f) =>
+    /preact/i.test(readFileSync(path.join(assetsDir, f), 'utf8')),
+);
+assert.ok(
+    preactChunk,
+    'no separate chunk contains "preact" — expected the QuantaDevTools dynamic import to produce one',
+);
+
+console.log(
+    `[verify-build] OK — entry: ${entryFile}, ${nonEntryChunks.length} split chunk(s), preact isolated in ${preactChunk}`,
+);

--- a/examples/react-vite/vite.config.ts
+++ b/examples/react-vite/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+    plugins: [react()],
+    build: {
+        outDir: 'dist',
+    },
+});

--- a/examples/vanilla/README.md
+++ b/examples/vanilla/README.md
@@ -1,0 +1,44 @@
+# QuantaJS — vanilla example
+
+`@quantajs/core` has no framework dependency. This example proves it by using
+the library directly against the DOM, and doubles as the reference for how
+to do that in your own project.
+
+## Run it
+
+```sh
+pnpm install
+pnpm --filter example-vanilla dev
+```
+
+## What's in here
+
+`index.html` + `src/main.ts` — a small page with three sections:
+
+- **Two counters**, each resolved from the same `defineStore` definition
+  against a *different* `createContainer()`. Bumping one never touches the
+  other — containers are the unit of isolation, and you get it without any
+  provider or framework glue.
+- **Todos** — getters, an async action (`seed()`), and `watch()` observing
+  the action's reactive `pending` flag. Configured with
+  `persist: { adapter: new LocalStorageAdapter(...) } }`, so the list
+  survives a reload.
+- **Reactivity primitives** — `reactive`, `computed`, `watch(..., { deep:
+  true })`, `effect`, `batchEffects` and `effectScope` used with no store at
+  all. This is the layer `defineStore` itself is built on.
+
+## Verifying the package, not just the demo
+
+`verify-esm.mjs` and `verify-cjs.cjs` are a separate concern from the
+browser demo above: they `import`/`require()` the **built** `dist` output
+and assert the real exports exist and behave correctly. Run them after
+building the package:
+
+```sh
+pnpm --filter @quantajs/core build
+pnpm --filter example-vanilla verify
+```
+
+These two scripts are the regression test for packaging bugs that source-only
+unit tests structurally cannot see — e.g. a CJS entry point that resolves to
+an empty object, or a build that silently drops an export.

--- a/examples/vanilla/index.html
+++ b/examples/vanilla/index.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>QuantaJS — vanilla example</title>
+        <style>
+            body {
+                font: 14px/1.5 system-ui, sans-serif;
+                max-width: 640px;
+                margin: 3rem auto;
+                padding: 0 1rem;
+                color: #1a1a1a;
+            }
+            section {
+                border: 1px solid #ddd;
+                border-radius: 8px;
+                padding: 1rem;
+                margin-bottom: 1.5rem;
+            }
+            h1 {
+                font-size: 1.25rem;
+            }
+            h2 {
+                font-size: 1rem;
+                margin-top: 0;
+            }
+            button {
+                cursor: pointer;
+            }
+            li.done {
+                text-decoration: line-through;
+                color: #888;
+            }
+            .muted {
+                color: #888;
+                font-size: 0.85em;
+            }
+        </style>
+    </head>
+    <body>
+        <h1>QuantaJS — vanilla (no framework)</h1>
+        <p class="muted">
+            <code>@quantajs/core</code> driving the DOM directly through
+            <code>store.subscribe()</code> — no React, no compiler. Two counter
+            widgets below each own an isolated <code>container</code>, so
+            clicking one never touches the other.
+        </p>
+
+        <section>
+            <h2>Counter A</h2>
+            <div id="counter-a"></div>
+        </section>
+
+        <section>
+            <h2>Counter B (isolated container)</h2>
+            <div id="counter-b"></div>
+        </section>
+
+        <section>
+            <h2>Todos (async action, getters, watch, persistence)</h2>
+            <p class="muted">
+                Backed by <code>persist: { adapter: new LocalStorageAdapter(...) }</code> —
+                reload the page and these survive.
+            </p>
+            <div id="todos"></div>
+        </section>
+
+        <section>
+            <h2>Reactivity primitives (no store)</h2>
+            <p class="muted">
+                <code>reactive</code>, <code>computed</code>,
+                <code>watch(..., { deep: true })</code>,
+                <code>effect</code>, <code>batchEffects</code> and
+                <code>effectScope</code> used directly.
+            </p>
+            <div id="reactivity"></div>
+        </section>
+
+        <script type="module" src="/src/main.ts"></script>
+    </body>
+</html>

--- a/examples/vanilla/package.json
+++ b/examples/vanilla/package.json
@@ -1,0 +1,19 @@
+{
+    "name": "example-vanilla",
+    "private": true,
+    "version": "0.0.0",
+    "type": "module",
+    "description": "No framework. @quantajs/core driving the DOM directly, plus ESM/CJS entry-point smoke tests against the built package.",
+    "scripts": {
+        "dev": "vite",
+        "build": "vite build",
+        "verify": "node verify-esm.mjs && node verify-cjs.cjs"
+    },
+    "dependencies": {
+        "@quantajs/core": "workspace:*"
+    },
+    "devDependencies": {
+        "typescript": "^6.0.2",
+        "vite": "^8.0.3"
+    }
+}

--- a/examples/vanilla/src/main.ts
+++ b/examples/vanilla/src/main.ts
@@ -1,0 +1,97 @@
+import { createContainer, watch } from '@quantajs/core';
+import { useCounterStore, useTodoStore } from './stores';
+import { mountReactivityPlayground } from './reactivity';
+
+/* --- Two isolated counters -------------------------------------------- *
+ * Same store *definition*, two different containers: `resolve()` is
+ * per-container, so bumping A never touches B. No provider, no framework —
+ * this is the isolation `defineStore` buys you for free.
+ */
+function mountCounter(root: HTMLElement, label: string) {
+    const container = createContainer(label);
+    const counter = useCounterStore(container);
+
+    root.innerHTML = `
+        <p>count: <strong data-count>0</strong> (doubled: <span data-doubled>0</span>)</p>
+        <button data-inc>+1</button>
+        <button data-reset>reset</button>
+    `;
+
+    const countEl = root.querySelector('[data-count]')!;
+    const doubledEl = root.querySelector('[data-doubled]')!;
+    root.querySelector('[data-inc]')!.addEventListener('click', () =>
+        counter.increment(),
+    );
+    root.querySelector('[data-reset]')!.addEventListener('click', () =>
+        counter.reset(),
+    );
+
+    const render = () => {
+        countEl.textContent = String(counter.count);
+        doubledEl.textContent = String(counter.doubled);
+    };
+    counter.subscribe(render);
+    render();
+}
+
+mountCounter(document.getElementById('counter-a')!, 'counter-a');
+mountCounter(document.getElementById('counter-b')!, 'counter-b');
+
+/* --- Todos: getters, an async action, and watch() ---------------------- */
+function mountTodos(root: HTMLElement) {
+    const todos = useTodoStore();
+
+    root.innerHTML = `
+        <form data-add>
+            <input data-input placeholder="Add a todo" />
+            <button type="submit">Add</button>
+            <button type="button" data-seed>Seed (async)</button>
+        </form>
+        <p data-status class="muted"></p>
+        <ul data-list></ul>
+        <p class="muted"><span data-remaining></span> remaining</p>
+    `;
+
+    const list = root.querySelector<HTMLUListElement>('[data-list]')!;
+    const input = root.querySelector<HTMLInputElement>('[data-input]')!;
+    const remainingEl = root.querySelector('[data-remaining]')!;
+    const statusEl = root.querySelector('[data-status]')!;
+
+    root.querySelector('[data-add]')!.addEventListener('submit', (e) => {
+        e.preventDefault();
+        const text = input.value.trim();
+        if (!text) return;
+        todos.add(text);
+        input.value = '';
+    });
+
+    root.querySelector('[data-seed]')!.addEventListener('click', () => {
+        void todos.seed();
+    });
+
+    // `watch` fires only when the tracked value actually changes — here just
+    // the async action's `pending` flag, not on every todo mutation.
+    watch(
+        () => todos.seed.pending,
+        (pending) => {
+            statusEl.textContent = pending ? 'Seeding…' : '';
+        },
+    );
+
+    const render = () => {
+        list.innerHTML = '';
+        for (const todo of todos.items) {
+            const li = document.createElement('li');
+            li.textContent = todo.text;
+            li.className = todo.done ? 'done' : '';
+            li.addEventListener('click', () => todos.toggle(todo.id));
+            list.appendChild(li);
+        }
+        remainingEl.textContent = String(todos.remaining);
+    };
+    todos.subscribe(render);
+    render();
+}
+
+mountTodos(document.getElementById('todos')!);
+mountReactivityPlayground(document.getElementById('reactivity')!);

--- a/examples/vanilla/src/reactivity.ts
+++ b/examples/vanilla/src/reactivity.ts
@@ -1,0 +1,91 @@
+import {
+    reactive,
+    computed,
+    watch,
+    effect,
+    effectScope,
+    batchEffects,
+} from '@quantajs/core';
+
+/**
+ * The primitives `defineStore` is built on, used directly — no store, no
+ * container. This is what "framework-agnostic" and "usable standalone"
+ * actually mean.
+ */
+export function mountReactivityPlayground(root: HTMLElement) {
+    const state = reactive({ a: 1, b: 2, nested: { c: 3 } });
+    const sum = computed(() => state.a + state.b);
+
+    root.innerHTML = `
+        <p>a = <span data-a></span>, b = <span data-b></span>, sum (computed) = <span data-sum></span></p>
+        <button data-bump-a>a++</button>
+        <button data-bump-both>a++ and b++ (batched)</button>
+        <button data-bump-nested>nested.c++ (deep watch)</button>
+        <button data-stop-scope>stop effectScope</button>
+        <p class="muted" data-log></p>
+    `;
+
+    const aEl = root.querySelector('[data-a]')!;
+    const bEl = root.querySelector('[data-b]')!;
+    const sumEl = root.querySelector('[data-sum]')!;
+    const logEl = root.querySelector('[data-log]')!;
+    const log: string[] = [];
+    const pushLog = (line: string) => {
+        log.unshift(line);
+        logEl.textContent = log.slice(0, 4).join(' · ');
+    };
+
+    // `effect` re-runs synchronously whenever a value it read changes.
+    let effectRuns = 0;
+    effect(() => {
+        aEl.textContent = String(state.a);
+        bEl.textContent = String(state.b);
+        sumEl.textContent = String(sum.value);
+        effectRuns++;
+    });
+
+    // `watch` with `deep: true` fires on a change anywhere inside the
+    // watched object, not just its top-level identity.
+    watch(
+        () => state.nested,
+        () => pushLog('nested changed (deep watch)'),
+        { deep: true },
+    );
+
+    root.querySelector('[data-bump-a]')!.addEventListener('click', () => {
+        state.a++;
+    });
+
+    root.querySelector('[data-bump-both]')!.addEventListener('click', () => {
+        // Without batchEffects, writing two dependencies of the same effect
+        // would run it twice. Batched, it runs once after both land.
+        const before = effectRuns;
+        batchEffects(() => {
+            state.a++;
+            state.b++;
+        });
+        pushLog(`2 writes inside batchEffects → effect ran ${effectRuns - before} time(s)`);
+    });
+
+    // effectScope groups effects so they can all be torn down together —
+    // the pattern a framework binding uses for "on unmount, stop everything
+    // this component started."
+    const scope = effectScope();
+    let scopedRuns = 0;
+    scope.run(() => {
+        effect(() => {
+            void state.nested.c;
+            scopedRuns++;
+        });
+    });
+
+    root.querySelector('[data-bump-nested]')!.addEventListener('click', () => {
+        state.nested.c++;
+        pushLog(`scoped effect has now run ${scopedRuns} time(s)`);
+    });
+
+    root.querySelector('[data-stop-scope]')!.addEventListener('click', () => {
+        scope.stop();
+        pushLog('scope stopped — nested.c++ will no longer move the counter above');
+    });
+}

--- a/examples/vanilla/src/stores.ts
+++ b/examples/vanilla/src/stores.ts
@@ -1,0 +1,63 @@
+import { defineStore, LocalStorageAdapter } from '@quantajs/core';
+
+/**
+ * A store definition is safe to share at module scope — it holds no state
+ * itself, only a name and a blueprint. State only exists once it is resolved
+ * against a container.
+ */
+export const useCounterStore = defineStore('counter', {
+    state: () => ({ count: 0 }),
+    getters: {
+        doubled: (s) => s.count * 2,
+    },
+    actions: {
+        increment() {
+            this.count++;
+        },
+        reset() {
+            this.count = 0;
+        },
+    },
+});
+
+export interface Todo {
+    id: number;
+    text: string;
+    done: boolean;
+}
+
+export const useTodoStore = defineStore('todos', {
+    state: () => ({
+        items: [] as Todo[],
+        nextId: 1,
+    }),
+    // Survives a page reload via localStorage. The adapter is SSR-safe (it
+    // degrades to a no-op when `window` doesn't exist), so this same
+    // definition is safe to reuse in the SSR examples without a guard.
+    persist: {
+        adapter: new LocalStorageAdapter('quanta-example-todos'),
+    },
+    getters: {
+        remaining: (s) => s.items.filter((t) => !t.done).length,
+    },
+    actions: {
+        add(text: string) {
+            this.items.push({ id: this.nextId++, text, done: false });
+        },
+        toggle(id: number) {
+            const todo = this.items.find((t) => t.id === id);
+            if (todo) todo.done = !todo.done;
+        },
+        /**
+         * An async action: `pending` and `error` are tracked automatically and
+         * are themselves reactive, so a plain `store.subscribe()` picks up the
+         * loading state with no extra wiring.
+         */
+        async seed() {
+            await new Promise((resolve) => setTimeout(resolve, 400));
+            for (const text of ['Read the docs', 'Ship a container per request']) {
+                this.items.push({ id: this.nextId++, text, done: false });
+            }
+        },
+    },
+});

--- a/examples/vanilla/tsconfig.json
+++ b/examples/vanilla/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "compilerOptions": {
+        "target": "ESNext",
+        "module": "ESNext",
+        "lib": ["ESNext", "DOM"],
+        "moduleResolution": "Bundler",
+        "strict": true,
+        "skipLibCheck": true,
+        "noEmit": true
+    },
+    "include": ["src"]
+}

--- a/examples/vanilla/verify-cjs.cjs
+++ b/examples/vanilla/verify-cjs.cjs
@@ -1,0 +1,70 @@
+// Smoke-tests the *built* @quantajs/core package through its CJS entry
+// point (package.json "exports" -> "require"). This is the direct
+// regression test for the packaging bug where `require('@quantajs/core')`
+// silently returned `{}` and every export was written onto `globalThis`
+// instead: a UMD bundle emitted under `.js` was parsed as ESM because the
+// package is `"type": "module"`, so `module.exports` was never reached.
+const assert = require('node:assert/strict');
+const quanta = require('@quantajs/core');
+
+const expectedExports = [
+    'reactive',
+    'computed',
+    'watch',
+    'effect',
+    'effectScope',
+    'batchEffects',
+    'defineStore',
+    'createStore',
+    'createContainer',
+    'getDefaultContainer',
+    'LocalStorageAdapter',
+];
+for (const name of expectedExports) {
+    assert.equal(
+        typeof quanta[name],
+        'function',
+        `@quantajs/core CJS export "${name}" is missing or not callable`,
+    );
+}
+// The bug this guards against left `module.exports` as `{}` while quietly
+// writing everything onto the global object instead — so also assert
+// nothing leaked there.
+assert.equal(
+    globalThis.QuantaJS,
+    undefined,
+    '@quantajs/core must not leak its exports onto globalThis',
+);
+
+const { defineStore, createContainer } = quanta;
+
+const useCounter = defineStore('cjs-counter', {
+    state: () => ({ count: 0 }),
+    getters: { doubled: (s) => s.count * 2 },
+    actions: {
+        increment() {
+            this.count++;
+        },
+    },
+});
+
+const container = createContainer('verify-cjs');
+const counter = useCounter(container);
+counter.increment();
+counter.increment();
+counter.increment();
+assert.equal(counter.count, 3, 'action mutated state');
+assert.equal(counter.doubled, 6, 'getter derived from state');
+
+const snapshot = container.dehydrate();
+assert.deepEqual(snapshot['cjs-counter'], { count: 3 }, 'dehydrate() snapshot');
+
+const client = createContainer('verify-cjs-client');
+client.hydrate(snapshot);
+const hydrated = useCounter(client);
+assert.equal(hydrated.count, 3, 'hydrate() restored state before first read');
+
+container.dispose();
+client.dispose();
+
+console.log('[verify-cjs] @quantajs/core CJS entry point OK');

--- a/examples/vanilla/verify-esm.mjs
+++ b/examples/vanilla/verify-esm.mjs
@@ -1,0 +1,81 @@
+// Smoke-tests the *built* @quantajs/core package through its ESM entry
+// point (package.json "exports" -> "import"). Run after `pnpm build`, not
+// against source — the point is to catch packaging bugs (wrong output
+// format, a dropped export, a bundler mis-resolving `.mjs`) that unit tests
+// running against `src/` never see.
+import assert from 'node:assert/strict';
+import * as quanta from '@quantajs/core';
+import {
+    defineStore,
+    createContainer,
+    reactive,
+    computed,
+    watch,
+} from '@quantajs/core';
+
+// The direct regression test for a package that quietly ships `export {}`:
+// assert every documented top-level export actually exists on the module,
+// not just that the ones this script happens to destructure are defined.
+const expectedExports = [
+    'reactive',
+    'computed',
+    'watch',
+    'effect',
+    'effectScope',
+    'batchEffects',
+    'defineStore',
+    'createStore',
+    'createContainer',
+    'getDefaultContainer',
+    'LocalStorageAdapter',
+];
+for (const name of expectedExports) {
+    assert.equal(
+        typeof quanta[name],
+        'function',
+        `@quantajs/core ESM export "${name}" is missing or not callable`,
+    );
+}
+
+const useCounter = defineStore('esm-counter', {
+    state: () => ({ count: 0 }),
+    getters: { doubled: (s) => s.count * 2 },
+    actions: {
+        increment() {
+            this.count++;
+        },
+    },
+});
+
+const container = createContainer('verify-esm');
+const counter = useCounter(container);
+counter.increment();
+counter.increment();
+assert.equal(counter.count, 2, 'action mutated state');
+assert.equal(counter.doubled, 4, 'getter derived from state');
+
+const snapshot = container.dehydrate();
+assert.deepEqual(snapshot['esm-counter'], { count: 2 }, 'dehydrate() snapshot');
+
+const client = createContainer('verify-esm-client');
+client.hydrate(snapshot);
+const hydrated = useCounter(client);
+assert.equal(hydrated.count, 2, 'hydrate() restored state before first read');
+
+const state = reactive({ value: 1 });
+const doubledRef = computed(() => state.value * 2);
+let seen;
+watch(
+    () => doubledRef.value,
+    (v) => {
+        seen = v;
+    },
+);
+state.value = 5;
+assert.equal(doubledRef.value, 10, 'computed recomputes');
+assert.equal(seen, 10, 'watch fires on the recomputed value');
+
+container.dispose();
+client.dispose();
+
+console.log('[verify-esm] @quantajs/core ESM entry point OK');

--- a/examples/vanilla/vite.config.ts
+++ b/examples/vanilla/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+    build: {
+        outDir: 'dist',
+    },
+});

--- a/package.json
+++ b/package.json
@@ -2,21 +2,23 @@
   "name": "quantajs",
   "private": true,
   "scripts": {
-    "dev": "pnpm -r dev",
-    "build": "pnpm -r build",
-    "preview": "pnpm -r preview",
-    "clean": "pnpm -r clean",
+    "dev": "pnpm --filter \"./packages/**\" dev",
+    "build": "pnpm --filter \"./packages/**\" build",
+    "preview": "pnpm --filter \"./packages/**\" preview",
+    "clean": "pnpm --filter \"./packages/**\" clean",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "test:types": "pnpm -r test:types",
+    "test:types": "pnpm --filter \"./packages/**\" test:types",
     "bench": "vitest bench",
-    "lint": "pnpm -r lint",
-    "lint:fix": "pnpm -r lint:fix",
+    "lint": "pnpm --filter \"./packages/**\" lint",
+    "lint:fix": "pnpm --filter \"./packages/**\" lint:fix",
     "format": "prettier --write \"packages/**/*.{ts,tsx,js,jsx,json,css,scss,md}\"",
     "changeset": "changeset",
     "version:update": "pnpm changeset version && pnpm install",
-    "publish": "pnpm build && pnpm changeset publish"
+    "publish": "pnpm build && pnpm changeset publish",
+    "examples:build": "pnpm --filter \"./examples/**\" build",
+    "examples:verify": "pnpm --filter \"./examples/**\" verify"
   },
   "devDependencies": {
     "@changesets/cli": "^2.30.0",
@@ -46,7 +48,8 @@
     "vitest": "^4.0.18"
   },
   "workspaces": [
-    "packages/*"
+    "packages/*",
+    "examples/*"
   ],
   "pnpm": {
     "overrides": {

--- a/packages/core/src/__tests__/container.test.ts
+++ b/packages/core/src/__tests__/container.test.ts
@@ -198,6 +198,37 @@ describe('containers', () => {
     });
 });
 
+describe('getters read through store.subscribe()', () => {
+    it('never serves a stale computed value to a coarse subscriber', () => {
+        // Regression test: a getter read once (priming its cache) before any
+        // mutation, then read again from inside `store.subscribe()` after an
+        // action mutates its dependency, used to alternate between the fresh
+        // value and the one from *before* that mutation. The store's own
+        // "something changed" notifier and the getter's cache-invalidation
+        // are two independent effects triggered by the same write; both are
+        // deferred to the same `batchEffects` flush (every action runs
+        // inside one), and the notifier happened to flush first — so it
+        // could read the getter before its cache had been invalidated.
+        const definition = counter();
+        const store = definition();
+
+        const seenByAction = new Map<number, number>();
+        store.subscribe(() => {
+            seenByAction.set(store.count, store.doubled);
+        });
+
+        // Priming read, before any mutation — the condition that exposed the
+        // bug: it's what causes the getter's underlying effect to register
+        // *after* the store's own notifier effect for the same dependency.
+        void store.doubled;
+
+        for (let i = 1; i <= 6; i++) {
+            store.bump();
+            expect(seenByAction.get(store.count)).toBe(store.count * 2);
+        }
+    });
+});
+
 describe('default container', () => {
     it('is used when no container is passed', () => {
         const definition = counter();

--- a/packages/core/src/core/effect.ts
+++ b/packages/core/src/core/effect.ts
@@ -10,6 +10,22 @@ export interface EffectOptions {
     /** If true, the effect will not run immediately upon creation. */
     lazy?: boolean;
     /**
+     * Run the scheduler immediately when a dependency changes, even inside an
+     * active `batchEffects()`, instead of deferring it to the batch flush.
+     *
+     * For an ordinary effect, deferring is correct — it is how N writes
+     * inside one batch collapse into one subscriber notification. A
+     * `computed`'s scheduler is different: it only flips a `dirty` flag, an
+     * idempotent, side-effect-free step with no reason to wait. If it *is*
+     * deferred, a plain effect that also depends on the same source (e.g. a
+     * store's coarse "something changed" notifier) can run first in the same
+     * flush pass and read the computed before it has been invalidated —
+     * serving a value that is one write stale. Marking the flag eagerly
+     * closes that window; the scheduler's own `trigger()` call for
+     * *downstream* subscribers still goes through normal batching.
+     */
+    eager?: boolean;
+    /**
      * Called when the effect is stopped. Used by {@link effectScope} and by
      * framework adapters that need to release resources with the effect.
      */
@@ -28,6 +44,8 @@ export interface EffectRunner extends EffectFunction {
     stop: () => void;
     /** Custom scheduler (if provided). */
     scheduler?: (effect: EffectRunner) => void;
+    /** Whether the scheduler runs immediately, bypassing batch deferral. */
+    eager?: boolean;
 }
 
 /** target -> (property -> Dependency) */
@@ -120,8 +138,10 @@ function scheduleEffect(effect: EffectFunction, errors: unknown[]): void {
     if (runner.active === false) return;
 
     // Inside a batch we only record the effect; the outermost batch flushes it.
-    // The Set dedupes, which is what collapses N writes into one run.
-    if (batchDepth > 0) {
+    // The Set dedupes, which is what collapses N writes into one run. An
+    // `eager` effect (a computed's invalidation) skips this queue — see
+    // {@link EffectOptions.eager}.
+    if (batchDepth > 0 && !runner.eager) {
         effectQueue.add(effect);
         return;
     }
@@ -421,6 +441,9 @@ export function reactiveEffect(
 
     if (options?.scheduler) {
         wrappedEffect.scheduler = options.scheduler;
+    }
+    if (options?.eager) {
+        wrappedEffect.eager = true;
     }
 
     effectDeps.set(wrappedEffect, deps);

--- a/packages/core/src/state/computed.ts
+++ b/packages/core/src/state/computed.ts
@@ -120,6 +120,11 @@ const computed = <T>(getter: () => T): ComputedRef<T> => {
                 dirty = true;
                 trigger(ref, 'value');
             },
+            // Flip `dirty` immediately, even inside a batch — see
+            // {@link EffectOptions.eager}. Without this, a coarse subscriber
+            // triggered by the same batched write can read `.value` before
+            // this scheduler has run and get a value that's one write stale.
+            eager: true,
         },
     );
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -60,7 +60,9 @@
     },
     "devDependencies": {
         "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.4",
         "react": "^19.2.4",
+        "react-dom": "^19.2.4",
         "@quantajs/devtools": "workspace:*"
     },
     "peerDependenciesMeta": {

--- a/packages/react/src/__tests__/ssr.test.tsx
+++ b/packages/react/src/__tests__/ssr.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Drives the dehydrate/hydrate round trip through the *real* SSR and
+ * hydration APIs — `react-dom/server`'s `renderToString` and
+ * `react-dom/client`'s `hydrateRoot` — rather than `@testing-library/react`'s
+ * `render()`, which never produces server markup and so can't catch a
+ * mismatch between what the server sent and what the client hydrates onto.
+ *
+ * This is the fast, framework-free complement to `examples/nextjs-app`:
+ * everything here that doesn't require an actual RSC boundary or bundler,
+ * covered in milliseconds instead of a `next build`.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { act } from 'react';
+import { renderToString } from 'react-dom/server';
+import { createRoot, hydrateRoot, type Root } from 'react-dom/client';
+import {
+    createContainer,
+    defineStore,
+    destroyAllStores,
+    type ContainerSnapshot,
+} from '@quantajs/core';
+import { QuantaProvider } from '../components/QuantaProvider';
+import { useQuanta } from '../hooks/useStore';
+
+// Not going through @testing-library/react here (it sets this itself) — this
+// test drives `react-dom` directly, so `act()` needs telling this *is* a
+// test environment or React logs a warning on every call.
+(
+    globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+let uid = 0;
+const name = (p = 'ssr') => `${p}_${++uid}_${Date.now()}`;
+
+afterEach(() => {
+    destroyAllStores();
+});
+
+const counterDefinition = () =>
+    defineStore(name('counter'), {
+        state: () => ({ count: 0 }),
+        getters: { doubled: (s) => s.count * 2 },
+        actions: {
+            increment() {
+                this.count++;
+            },
+        },
+    });
+
+describe('SSR: renderToString -> hydrateRoot', () => {
+    it('hydrates onto server-rendered markup with no mismatch and stays live', () => {
+        const definition = counterDefinition();
+
+        // --- "server" ------------------------------------------------
+        const server = createContainer('ssr-server');
+        const serverCounter = definition(server);
+        serverCounter.increment();
+        serverCounter.increment();
+        serverCounter.increment();
+
+        const App = () => {
+            const counter = useQuanta(definition);
+            return (
+                <button data-testid="count" onClick={() => counter.increment()}>
+                    {counter.count} (doubled: {counter.doubled})
+                </button>
+            );
+        };
+
+        const html = renderToString(
+            <QuantaProvider container={server}>
+                <App />
+            </QuantaProvider>,
+        );
+
+        const snapshot: ContainerSnapshot = server.dehydrate();
+        server.dispose();
+
+        // --- "client" -------------------------------------------------
+        // A fresh container, hydrated from the server's snapshot — exactly
+        // the round trip a real app does, not a container shared by
+        // reference across the boundary.
+        const container = document.createElement('div');
+        container.innerHTML = html;
+        document.body.appendChild(container);
+
+        // Read via textContent, not the raw HTML string: React separates
+        // adjacent text-producing children with `<!-- -->` comments in SSR
+        // output so hydration can match each one to its own text node —
+        // real behavior, not a fixture detail.
+        expect(container.textContent).toBe('3 (doubled: 6)');
+
+        const errors: unknown[][] = [];
+        const originalError = console.error;
+        console.error = (...args: unknown[]) => {
+            errors.push(args);
+        };
+
+        let root!: Root;
+        try {
+            act(() => {
+                root = hydrateRoot(
+                    container,
+                    <QuantaProvider snapshot={snapshot}>
+                        <App />
+                    </QuantaProvider>,
+                );
+            });
+        } finally {
+            console.error = originalError;
+        }
+
+        // A hydration mismatch is exactly the class of bug this test exists
+        // to catch — React reports it through console.error, not a thrown
+        // exception.
+        const mismatchErrors = errors.filter((args) =>
+            String(args[0]).toLowerCase().includes('hydrat'),
+        );
+        expect(mismatchErrors).toEqual([]);
+
+        // The value the client hydrated onto is the server's value, never a
+        // flash of default state.
+        const button = container.querySelector(
+            '[data-testid="count"]',
+        ) as HTMLButtonElement;
+        expect(button.textContent).toBe('3 (doubled: 6)');
+
+        // Hydration wires up real event handlers, not just markup — the
+        // store built with `state`/`getters`/`actions` is live after the
+        // round trip.
+        act(() => {
+            button.click();
+        });
+        expect(button.textContent).toBe('4 (doubled: 8)');
+
+        act(() => {
+            root.unmount();
+        });
+        container.remove();
+    });
+
+    it('renders default state with no server container, matching a client-only render', () => {
+        const definition = counterDefinition();
+
+        const App = () => {
+            const counter = useQuanta(definition);
+            return <span>{counter.count}</span>;
+        };
+
+        const html = renderToString(
+            <QuantaProvider>
+                <App />
+            </QuantaProvider>,
+        );
+        expect(html).toContain('>0<');
+
+        const container = document.createElement('div');
+        document.body.appendChild(container);
+        let root!: Root;
+        act(() => {
+            root = createRoot(container);
+            root.render(
+                <QuantaProvider>
+                    <App />
+                </QuantaProvider>,
+            );
+        });
+        expect(container.textContent).toBe('0');
+
+        act(() => {
+            root.unmount();
+        });
+        container.remove();
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: ^16.3.2
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/node':
         specifier: ^25.3.5
         version: 25.5.0
@@ -73,19 +73,97 @@ importers:
         version: 6.0.2
       vite:
         specifier: ^8.0.3
-        version: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)
+        version: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.11.3)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)
       vite-plugin-banner:
         specifier: ^0.8.1
         version: 0.8.1
       vite-plugin-dts:
         specifier: ^4.5.4
-        version: 4.5.4(@types/node@25.5.0)(rollup@4.60.0)(typescript@6.0.2)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1))
+        version: 4.5.4(@types/node@25.5.0)(rollup@4.60.0)(typescript@6.0.2)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.11.3)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1))
       vite-plugin-eslint:
         specifier: ^1.8.1
-        version: 1.8.1(eslint@10.1.0(jiti@2.6.1))(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1))
+        version: 1.8.1(eslint@10.1.0(jiti@2.6.1))(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.11.3)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1))
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@25.5.0)(happy-dom@20.8.9)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)
+
+  examples/nextjs-app:
+    dependencies:
+      '@quantajs/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@quantajs/react':
+        specifier: workspace:*
+        version: link:../../packages/react
+      next:
+        specifier: ^16.3.1
+        version: 16.3.1(@types/node@25.5.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react:
+        specifier: ^19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.4(react@19.2.4)
+    devDependencies:
+      '@types/node':
+        specifier: ^25.3.5
+        version: 25.5.0
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.4
+        version: 19.2.4(@types/react@19.2.14)
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.2
+
+  examples/react-vite:
+    dependencies:
+      '@quantajs/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@quantajs/devtools':
+        specifier: workspace:*
+        version: link:../../packages/devtools
+      '@quantajs/react':
+        specifier: workspace:*
+        version: link:../../packages/react
+      react:
+        specifier: ^19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.4(react@19.2.4)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.4
+        version: 19.2.4(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.5
+        version: 6.0.5(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.11.3)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1))
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.2
+      vite:
+        specifier: ^8.0.3
+        version: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.11.3)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)
+
+  examples/vanilla:
+    dependencies:
+      '@quantajs/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+    devDependencies:
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.2
+      vite:
+        specifier: ^8.0.3
+        version: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.11.3)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)
 
   packages/core: {}
 
@@ -97,7 +175,7 @@ importers:
     devDependencies:
       '@preact/preset-vite':
         specifier: ^2.10.3
-        version: 2.10.3(@babel/core@7.29.0)(preact@10.28.4)(rollup@4.60.0)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1))
+        version: 2.10.3(@babel/core@7.29.0)(preact@10.28.4)(rollup@4.60.0)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.11.3)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1))
       '@quantajs/core':
         specifier: workspace:*
         version: link:../core
@@ -114,9 +192,15 @@ importers:
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.4
+        version: 19.2.4(@types/react@19.2.14)
       react:
         specifier: ^19.2.4
         version: 19.2.4
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.4(react@19.2.4)
 
 packages:
 
@@ -282,8 +366,8 @@ packages:
   '@emnapi/core@1.9.1':
     resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
 
-  '@emnapi/runtime@1.9.1':
-    resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
 
   '@emnapi/wasi-threads@1.2.0':
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
@@ -503,6 +587,168 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.35.3':
+    resolution: {integrity: sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.35.3':
+    resolution: {integrity: sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-freebsd-wasm32@0.35.3':
+    resolution: {integrity: sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==}
+    engines: {node: '>=20.9.0'}
+    os: [freebsd]
+
+  '@img/sharp-libvips-darwin-arm64@1.3.2':
+    resolution: {integrity: sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.3.2':
+    resolution: {integrity: sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.3.2':
+    resolution: {integrity: sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.3.2':
+    resolution: {integrity: sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.3.2':
+    resolution: {integrity: sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.3.2':
+    resolution: {integrity: sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.3.2':
+    resolution: {integrity: sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.3.2':
+    resolution: {integrity: sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
+    resolution: {integrity: sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
+    resolution: {integrity: sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.35.3':
+    resolution: {integrity: sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.35.3':
+    resolution: {integrity: sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.35.3':
+    resolution: {integrity: sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.35.3':
+    resolution: {integrity: sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.35.3':
+    resolution: {integrity: sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==}
+    engines: {node: '>=20.9.0'}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.35.3':
+    resolution: {integrity: sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.35.3':
+    resolution: {integrity: sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.35.3':
+    resolution: {integrity: sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.35.3':
+    resolution: {integrity: sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==}
+    engines: {node: '>=20.9.0'}
+
+  '@img/sharp-webcontainers-wasm32@0.35.3':
+    resolution: {integrity: sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==}
+    engines: {node: '>=20.9.0'}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.35.3':
+    resolution: {integrity: sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.35.3':
+    resolution: {integrity: sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==}
+    engines: {node: ^20.9.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.35.3':
+    resolution: {integrity: sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [win32]
+
   '@inquirer/external-editor@1.0.3':
     resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
     engines: {node: '>=18'}
@@ -555,6 +801,61 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@next/env@16.3.1':
+    resolution: {integrity: sha512-35G3xwkQUb2oETSDjFXGrVugknoayLFBh7vSE+yAcl9IP2zT9wyGwq7297AYHR11kJld807t5f8AJBs6WBzXsQ==}
+
+  '@next/swc-darwin-arm64@16.3.1':
+    resolution: {integrity: sha512-ABMIu2zQ7cnNIHm5ivKGwZwUrm0pAai3yiJ/gK/rF1c1VP9UOnj7XECbMKFdVKp9I9eMYq9NoDs1WXOoowxzJw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-x64@16.3.1':
+    resolution: {integrity: sha512-gNG21e/UnrroeScbY/QndUEdl0mF1FRibW7BBeYUz/5ABCepjqDdEdgr592vpzMtCn/m7FTjYq3TN4TpyDnutw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@next/swc-linux-arm64-gnu@16.3.1':
+    resolution: {integrity: sha512-6B6Lw016iwNUQuaJoraMMTLh6TwHzFUtxipSScD1F3YyymcrRWkobodRS2ftIOkF5vrs4zNlyUrTC5YZQ9Lz5w==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-arm64-musl@16.3.1':
+    resolution: {integrity: sha512-JUiPXZKK9wOhjf4MgDiH29GZLxfqOesbLtHq2pDxwH/WwscTRV2ToymnOTh1egzaZf0ueUf8T2+CeYTGHjW0Iw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-linux-x64-gnu@16.3.1':
+    resolution: {integrity: sha512-Uog9jsrmIRIL/lfvIp9htmskSNC7JcQsMVucXL2V2YY1y/D9IUN3LPEafqy0zRJ2cIU1SQ0V6F6TlffQ+pLAGg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-x64-musl@16.3.1':
+    resolution: {integrity: sha512-6yy3FT13KgUFOj5H8bl8w/6nKiJwHIvbtwh1V+1acsu+7y4tJjnemSa6mhsh53BeoVrlozE+fMgZhXH46WmjMA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-win32-arm64-msvc@16.3.1':
+    resolution: {integrity: sha512-iOoN1QecUoGNZik536U/vtK43YwgyrCsGIkth52yIkl612n+0C9MjSnJbQAikISpb+WYRooBVhaDlUW7iZoKog==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@16.3.1':
+    resolution: {integrity: sha512-d/k+PpAriUPaeMJJOG7HUSdqfEX46FEPWU1p3/nm2ACmXhj9hFEWdFODUBIpkuijXYkfL90qZzTqVPRp4BW/hw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -695,6 +996,9 @@ packages:
 
   '@rolldown/pluginutils@1.0.0-rc.12':
     resolution: {integrity: sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==}
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
   '@rollup/pluginutils@4.2.1':
     resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
@@ -883,6 +1187,9 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
+
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
@@ -941,6 +1248,11 @@ packages:
 
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
+
+  '@types/react-dom@19.2.4':
+    resolution: {integrity: sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==}
+    peerDependencies:
+      '@types/react': ^19.2.0
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
@@ -1009,6 +1321,19 @@ packages:
   '@typescript-eslint/visitor-keys@8.56.1':
     resolution: {integrity: sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@vitejs/plugin-react@6.0.5':
+    resolution: {integrity: sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
 
   '@vitest/coverage-v8@4.0.18':
     resolution: {integrity: sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==}
@@ -1242,6 +1567,9 @@ packages:
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+
+  client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -2119,8 +2447,34 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  next@16.3.1:
+    resolution: {integrity: sha512-hsAp0i7Rh+/dhe7DGIeN2YlpLM1DP4MNxti9EtDMtqcO612X81MvvEj388/oTce9U1EcEIOWDlGq0zRwrBKvuA==}
+    engines: {node: '>=20.9.0'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
 
   node-html-parser@6.1.13:
     resolution: {integrity: sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==}
@@ -2256,6 +2610,10 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
+    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
@@ -2400,6 +2758,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
@@ -2411,6 +2774,15 @@ packages:
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
+
+  sharp@0.35.3:
+    resolution: {integrity: sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -2516,6 +2888,19 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  styled-jsx@5.1.6:
+    resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -3115,7 +3500,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.9.1':
+  '@emnapi/runtime@1.11.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -3262,6 +3647,113 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@img/colour@1.1.0':
+    optional: true
+
+  '@img/sharp-darwin-arm64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.3.2
+    optional: true
+
+  '@img/sharp-darwin-x64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.3.2
+    optional: true
+
+  '@img/sharp-freebsd-wasm32@0.35.3':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.3
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-arm@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-s390x@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-x64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.3.2
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
+    optional: true
+
+  '@img/sharp-wasm32@0.35.3':
+    dependencies:
+      '@emnapi/runtime': 1.11.3
+    optional: true
+
+  '@img/sharp-webcontainers-wasm32@0.35.3':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.3
+    optional: true
+
+  '@img/sharp-win32-arm64@0.35.3':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.35.3':
+    optional: true
+
+  '@img/sharp-win32-x64@0.35.3':
+    optional: true
+
   '@inquirer/external-editor@1.0.3(@types/node@25.5.0)':
     dependencies:
       chardet: 2.1.1
@@ -3345,11 +3837,37 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@napi-rs/wasm-runtime@1.1.2(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)':
+  '@napi-rs/wasm-runtime@1.1.2(@emnapi/core@1.9.1)(@emnapi/runtime@1.11.3)':
     dependencies:
       '@emnapi/core': 1.9.1
-      '@emnapi/runtime': 1.9.1
+      '@emnapi/runtime': 1.11.3
       '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@next/env@16.3.1': {}
+
+  '@next/swc-darwin-arm64@16.3.1':
+    optional: true
+
+  '@next/swc-darwin-x64@16.3.1':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@16.3.1':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@16.3.1':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@16.3.1':
+    optional: true
+
+  '@next/swc-linux-x64-musl@16.3.1':
+    optional: true
+
+  '@next/swc-win32-arm64-msvc@16.3.1':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@16.3.1':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -3368,18 +3886,18 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@preact/preset-vite@2.10.3(@babel/core@7.29.0)(preact@10.28.4)(rollup@4.60.0)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1))':
+  '@preact/preset-vite@2.10.3(@babel/core@7.29.0)(preact@10.28.4)(rollup@4.60.0)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.11.3)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
       '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.29.0)
-      '@prefresh/vite': 2.4.12(preact@10.28.4)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1))
+      '@prefresh/vite': 2.4.12(preact@10.28.4)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.11.3)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1))
       '@rollup/pluginutils': 5.3.0(rollup@4.60.0)
       babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.29.0)
       debug: 4.4.3
       picocolors: 1.1.1
-      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)
-      vite-prerender-plugin: 0.5.12(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1))
+      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.11.3)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)
+      vite-prerender-plugin: 0.5.12(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.11.3)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1))
     transitivePeerDependencies:
       - preact
       - rollup
@@ -3393,7 +3911,7 @@ snapshots:
 
   '@prefresh/utils@1.2.1': {}
 
-  '@prefresh/vite@2.4.12(preact@10.28.4)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1))':
+  '@prefresh/vite@2.4.12(preact@10.28.4)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.11.3)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1))':
     dependencies:
       '@babel/core': 7.29.0
       '@prefresh/babel-plugin': 0.5.3
@@ -3401,7 +3919,7 @@ snapshots:
       '@prefresh/utils': 1.2.1
       '@rollup/pluginutils': 4.2.1
       preact: 10.28.4
-      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)
+      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.11.3)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -3441,9 +3959,9 @@ snapshots:
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)':
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12(@emnapi/core@1.9.1)(@emnapi/runtime@1.11.3)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.2(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
+      '@napi-rs/wasm-runtime': 1.1.2(@emnapi/core@1.9.1)(@emnapi/runtime@1.11.3)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -3456,6 +3974,8 @@ snapshots:
     optional: true
 
   '@rolldown/pluginutils@1.0.0-rc.12': {}
+
+  '@rolldown/pluginutils@1.0.1': {}
 
   '@rollup/pluginutils@4.2.1':
     dependencies:
@@ -3588,6 +4108,10 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@swc/helpers@0.5.23':
+    dependencies:
+      tslib: 2.8.1
+
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -3608,7 +4132,7 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@testing-library/dom': 10.4.1
@@ -3616,6 +4140,7 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
@@ -3651,6 +4176,10 @@ snapshots:
   '@types/node@25.5.0':
     dependencies:
       undici-types: 7.18.2
+
+  '@types/react-dom@19.2.4(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
 
   '@types/react@19.2.14':
     dependencies:
@@ -3752,6 +4281,11 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.56.1
       eslint-visitor-keys: 5.0.1
+
+  '@vitejs/plugin-react@6.0.5(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.11.3)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.11.3)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)
 
   '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@25.5.0)(happy-dom@20.8.9)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1))':
     dependencies:
@@ -4021,6 +4555,8 @@ snapshots:
   chai@6.2.2: {}
 
   chardet@2.1.1: {}
+
+  client-only@0.0.1: {}
 
   commander@2.20.3: {}
 
@@ -4950,7 +5486,34 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanoid@3.3.18: {}
+
   natural-compare@1.4.0: {}
+
+  next@16.3.1(@types/node@25.5.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@next/env': 16.3.1
+      '@swc/helpers': 0.5.23
+      baseline-browser-mapping: 2.10.0
+      caniuse-lite: 1.0.30001772
+      postcss: 8.5.23
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      styled-jsx: 5.1.6(react@19.2.4)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.3.1
+      '@next/swc-darwin-x64': 16.3.1
+      '@next/swc-linux-arm64-gnu': 16.3.1
+      '@next/swc-linux-arm64-musl': 16.3.1
+      '@next/swc-linux-x64-gnu': 16.3.1
+      '@next/swc-linux-x64-musl': 16.3.1
+      '@next/swc-win32-arm64-msvc': 16.3.1
+      '@next/swc-win32-x64-msvc': 16.3.1
+      sharp: 0.35.3(@types/node@25.5.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@types/node'
+      - babel-plugin-macros
 
   node-html-parser@6.1.13:
     dependencies:
@@ -5088,6 +5651,12 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
+  postcss@8.5.23:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   postcss@8.5.8:
     dependencies:
       nanoid: 3.3.11
@@ -5178,7 +5747,7 @@ snapshots:
       glob: 13.0.6
       package-json-from-dist: 1.0.1
 
-  rolldown@1.0.0-rc.12(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1):
+  rolldown@1.0.0-rc.12(@emnapi/core@1.9.1)(@emnapi/runtime@1.11.3):
     dependencies:
       '@oxc-project/types': 0.122.0
       '@rolldown/pluginutils': 1.0.0-rc.12
@@ -5195,7 +5764,7 @@ snapshots:
       '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.12
       '@rolldown/binding-linux-x64-musl': 1.0.0-rc.12
       '@rolldown/binding-openharmony-arm64': 1.0.0-rc.12
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.12(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.12(@emnapi/core@1.9.1)(@emnapi/runtime@1.11.3)
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.12
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.12
     transitivePeerDependencies:
@@ -5272,6 +5841,9 @@ snapshots:
 
   semver@7.7.4: {}
 
+  semver@7.8.5:
+    optional: true
+
   set-function-length@1.2.2:
     dependencies:
       define-data-property: 1.1.4
@@ -5293,6 +5865,40 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
+
+  sharp@0.35.3(@types/node@25.5.0):
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.35.3
+      '@img/sharp-darwin-x64': 0.35.3
+      '@img/sharp-freebsd-wasm32': 0.35.3
+      '@img/sharp-libvips-darwin-arm64': 1.3.2
+      '@img/sharp-libvips-darwin-x64': 1.3.2
+      '@img/sharp-libvips-linux-arm': 1.3.2
+      '@img/sharp-libvips-linux-arm64': 1.3.2
+      '@img/sharp-libvips-linux-ppc64': 1.3.2
+      '@img/sharp-libvips-linux-riscv64': 1.3.2
+      '@img/sharp-libvips-linux-s390x': 1.3.2
+      '@img/sharp-libvips-linux-x64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
+      '@img/sharp-linux-arm': 0.35.3
+      '@img/sharp-linux-arm64': 0.35.3
+      '@img/sharp-linux-ppc64': 0.35.3
+      '@img/sharp-linux-riscv64': 0.35.3
+      '@img/sharp-linux-s390x': 0.35.3
+      '@img/sharp-linux-x64': 0.35.3
+      '@img/sharp-linuxmusl-arm64': 0.35.3
+      '@img/sharp-linuxmusl-x64': 0.35.3
+      '@img/sharp-webcontainers-wasm32': 0.35.3
+      '@img/sharp-win32-arm64': 0.35.3
+      '@img/sharp-win32-ia32': 0.35.3
+      '@img/sharp-win32-x64': 0.35.3
+      '@types/node': 25.5.0
+    optional: true
 
   shebang-command@2.0.0:
     dependencies:
@@ -5404,6 +6010,11 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  styled-jsx@5.1.6(react@19.2.4):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.4
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -5453,8 +6064,7 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   type-check@0.4.0:
     dependencies:
@@ -5524,7 +6134,7 @@ snapshots:
 
   vite-plugin-banner@0.8.1: {}
 
-  vite-plugin-dts@4.5.4(@types/node@25.5.0)(rollup@4.60.0)(typescript@6.0.2)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)):
+  vite-plugin-dts@4.5.4(@types/node@25.5.0)(rollup@4.60.0)(typescript@6.0.2)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.11.3)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)):
     dependencies:
       '@microsoft/api-extractor': 7.57.7(@types/node@25.5.0)
       '@rollup/pluginutils': 5.3.0(rollup@4.60.0)
@@ -5537,21 +6147,21 @@ snapshots:
       magic-string: 0.30.21
       typescript: 6.0.2
     optionalDependencies:
-      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)
+      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.11.3)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite-plugin-eslint@1.8.1(eslint@10.1.0(jiti@2.6.1))(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)):
+  vite-plugin-eslint@1.8.1(eslint@10.1.0(jiti@2.6.1))(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.11.3)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)):
     dependencies:
       '@rollup/pluginutils': 4.2.1
       '@types/eslint': 8.56.12
       eslint: 10.1.0(jiti@2.6.1)
       rollup: 2.80.0
-      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)
+      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.11.3)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)
 
-  vite-prerender-plugin@0.5.12(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)):
+  vite-prerender-plugin@0.5.12(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.11.3)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)):
     dependencies:
       kolorist: 1.8.0
       magic-string: 0.30.21
@@ -5559,7 +6169,7 @@ snapshots:
       simple-code-frame: 1.3.0
       source-map: 0.7.6
       stack-trace: 1.0.0-pre2
-      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)
+      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.11.3)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)
 
   vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1):
     dependencies:
@@ -5576,12 +6186,12 @@ snapshots:
       lightningcss: 1.32.0
       terser: 5.46.1
 
-  vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1):
+  vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.11.3)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
       postcss: 8.5.8
-      rolldown: 1.0.0-rc.12(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
+      rolldown: 1.0.0-rc.12(@emnapi/core@1.9.1)(@emnapi/runtime@1.11.3)
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 25.5.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
     - 'packages/*'
+    - 'examples/*'


### PR DESCRIPTION
## Description

Adds `examples/`: three small apps that consume the packages via `workspace:*` — resolved through each package's real `main`/`module`/`exports` fields, the way an external consumer would — so a breaking change fails CI on the commit that introduces it instead of surfacing later in a stale, separate example repo.

- **`examples/vanilla`** — no framework. `reactive`/`computed`/`watch(deep)`/`effect`/`batchEffects`/`effectScope` and `defineStore`/`createContainer` used directly against the DOM, plus persistence via `LocalStorageAdapter`. Separate `verify-esm.mjs`/`verify-cjs.cjs` smoke-test the **built** package's ESM and CJS entry points directly — the regression class for a `require()` returning `{}` packaging bug.
- **`examples/react-vite`** — `StrictMode` on, an explicit container passed to `QuantaProvider`, every hook (`useQuanta`, `useQuantaValue`, `useQuantaActions`, `useComputed`, `useWatch`, `useLocalStore`), an async action's `pending`/`error`/`abort()` in a real component, and `QuantaDevTools` mounted. `verify-build.mjs` inspects the production build output to confirm the lazy panel and DevTools (which pulls in Preact) each land in their own chunk rather than the main bundle.
- **`examples/nextjs-app`** — a Server Component creates a **per-request container**, dehydrates it, and hands the snapshot to a `'use client'` `QuantaProvider` boundary. `verify-build.mjs` confirms `next build` succeeds and that a client-reference-manifest exists, proving the `'use client'` boundary survived the real bundler.

Also adds a `renderToString` → `hydrateRoot` test directly in `packages/react`'s suite (no Next.js needed), covering the same dehydrate/hydrate round trip in milliseconds — for everything a real RSC boundary and bundler aren't structurally required to catch.

**Wiring:** `examples/*` join the pnpm workspace. Root scripts (`build`, `lint`, `test:types`, `dev`, etc.) are scoped to `packages/**` so the existing fast loop is unaffected; new `examples:build`/`examples:verify` scripts live under their own filter. CI gets a separate `examples` job (parallel to `bench`) so it doesn't slow down lint/test.

### A real bug this caught

While building these, exercising a plain `container.subscribe()` + getter in the browser (`examples/vanilla`) surfaced a genuine core reactivity bug: a getter read once (priming its cache), then read again from inside `store.subscribe()` after a batched mutation, alternated between the fresh value and the one from *before* that mutation. Root cause and fix are in the first commit, with a regression test and a changeset entry. The React hook layer had a related but distinct issue — `useQuanta`-resolved `pending`/`error` only appeared to update because it happened to coincide with a nearby state write — fixed by reading them through `useQuantaValue` selectors in the example instead.

## Checklist
- [x] My code builds and runs correctly (`pnpm build`, `pnpm lint`, `pnpm test:coverage`, `pnpm test:types`, `pnpm examples:build`, `pnpm examples:verify` all pass locally)
- [x] I have added tests that prove my fix is effective (`container.test.ts` regression test for the computed-invalidation fix; new `ssr.test.tsx`; each example's `verify` script)
- [x] I have added necessary documentation (a README per example)

## Related Issues

N/A — this implements the in-repo verification examples plan discussed separately, not a tracked issue.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KZR3tjTu84AVBSenDsgotm)_