### PR TITLE
fix(core): wire action lifecycle state into the store change-notifier

### DIFF
--- a/.changeset/quanta-2-1-0.md
+++ b/.changeset/quanta-2-1-0.md
@@ -140,6 +140,13 @@ Attached to synchronous actions too, so making an action async later is not a
 breaking change for its callers. Deliberately minimal — no caching, retries or
 invalidation, which belong to a server-state library.
 
+`pending` and `error` live on a reactive object separate from `state`, so the
+store's coarse change-notifier depends on both — otherwise `store.subscribe()`,
+and everything built on it including React's `useQuanta`, would miss a
+lifecycle change entirely unless the action happened to write state at around
+the same moment. One call notifies subscribers once, not once per field
+written; a synchronous action settles inside the same batch as its body.
+
 ### React
 
 - `useQuantaSelector` tracks **what the selector reads** rather than comparing

--- a/examples/react-vite/src/App.tsx
+++ b/examples/react-vite/src/App.tsx
@@ -59,13 +59,10 @@ function AddItemForm() {
 /**
  * Exercises an async action's `pending` / `error` / `abort()`.
  *
- * Reads them through `useQuantaValue` selectors rather than off a
- * `useQuanta`-resolved store: `pending`/`error` live on a separate reactive
- * object from the store's own `state`, and `useQuanta`'s whole-store
- * subscription only wakes on a `state` change. A selector tracks its read
- * directly, so it reacts to the two independently — reading them off
- * `useQuanta`'s store here would appear to work only by coincidence,
- * whenever a state write happens to land near the same tick.
+ * These are read through `useQuantaValue` selectors so this component wakes
+ * *only* for the checkout action's own lifecycle, not for every cart change —
+ * reading them off a `useQuanta`-resolved store works too, but subscribes to
+ * the whole store.
  */
 function CheckoutButton() {
     const cart = useQuantaActions(useCartStore);

--- a/packages/core/src/__tests__/container.test.ts
+++ b/packages/core/src/__tests__/container.test.ts
@@ -546,4 +546,74 @@ describe('async action lifecycle', () => {
         expect(captured?.aborted).toBe(true);
         await promise;
     });
+
+    /**
+     * `pending`/`error` live on a reactive object separate from `state`. They
+     * were reactive in isolation — a raw `effect()` reading them woke
+     * correctly — but the store's coarse change-notifier only enumerated
+     * `state`, so `store.subscribe()` never fired for them. Everything built
+     * on `subscribe` inherited the gap, including React's `useQuanta`, which
+     * made an action's loading flag appear to work only when that action also
+     * happened to write state at around the same moment.
+     */
+    describe('lifecycle changes reach store.subscribe()', () => {
+        const silentAction = () =>
+            defineStore(name('silent'), {
+                state: () => ({ untouched: 0 }),
+                actions: {
+                    // Deliberately writes no state, so the only thing a
+                    // subscriber could react to is the lifecycle flags.
+                    async run(shouldFail = false) {
+                        await Promise.resolve();
+                        if (shouldFail) throw new Error('nope');
+                    },
+                },
+            });
+
+        it('notifies when pending flips on and back off', async () => {
+            const store = silentAction()();
+            const seen: boolean[] = [];
+            store.subscribe(() => seen.push(store.run.pending));
+
+            const promise = store.run();
+            expect(seen).toContain(true);
+
+            await promise;
+            expect(seen[seen.length - 1]).toBe(false);
+        });
+
+        it('notifies when an action rejects', async () => {
+            const store = silentAction()();
+            let notifications = 0;
+            store.subscribe(() => notifications++);
+
+            await expect(store.run(true)).rejects.toThrow('nope');
+
+            expect(notifications).toBeGreaterThan(0);
+            expect(store.run.error?.message).toBe('nope');
+        });
+
+        it('notifies once per lifecycle transition, not once per field', () => {
+            // `pending` and `error` are both written when a call starts; that
+            // is one event, so it should wake subscribers once.
+            const store = silentAction()();
+            let notifications = 0;
+            store.subscribe(() => notifications++);
+
+            void store.run();
+
+            expect(notifications).toBe(1);
+        });
+
+        it('still notifies for an action that only writes state', () => {
+            // Guards the wiring above from breaking the ordinary path.
+            const store = counter()();
+            let notifications = 0;
+            store.subscribe(() => notifications++);
+
+            store.bump();
+
+            expect(notifications).toBe(1);
+        });
+    });
 });

--- a/packages/core/src/core/create-store.ts
+++ b/packages/core/src/core/create-store.ts
@@ -71,12 +71,38 @@ export function instantiateStore<
     /** Everything the store owns, released together by `$destroy`. */
     const scope: EffectScope = effectScope();
 
+    /**
+     * Per-action lifecycle state, keyed by action name.
+     *
+     * Declared here rather than beside the action wiring below because the
+     * store's coarse change-notifier has to depend on it: `pending`/`error`
+     * are reactive in their own right, but they live on a *separate* reactive
+     * object from `state`, so an effect watching only `state` never wakes when
+     * they flip. That made `store.subscribe()` — and everything built on it,
+     * including React's `useQuanta` — miss them entirely, except when an
+     * action happened to also write state at around the same time, which made
+     * it look intermittently correct.
+     */
+    const asyncState = reactive<
+        Record<string, { pending: number; error: Error | null }>
+    >({});
+
     scope.run(() => {
         reactiveEffect(() => {
             // Touch every top-level key so this effect depends on all of them;
             // nested changes arrive by bubbling.
             for (const key in state) {
                 void (state as Record<string, unknown>)[key];
+            }
+
+            // Same, for action lifecycle state. Enumerating also subscribes to
+            // the key set itself, so an action registered later (the actions
+            // are wired up after this effect is created) re-runs this and picks
+            // up its entry.
+            for (const key in asyncState) {
+                const entry = asyncState[key];
+                void entry.pending;
+                void entry.error;
             }
 
             // Subscriber callbacks routinely read reactive state. Without
@@ -283,15 +309,8 @@ export function instantiateStore<
     ) as unknown as Store<S, G, A>;
 
     // ---- actions -----------------------------------------------------
-    /**
-     * Per-action lifecycle state.
-     *
-     * Reactive so that `store.load.pending` read inside a component or effect
-     * subscribes to it like any other state.
-     */
-    const asyncState = reactive<
-        Record<string, { pending: number; error: Error | null }>
-    >({});
+    // `asyncState` is declared above, alongside the change-notifier that has
+    // to depend on it.
     const inFlight = new Map<string, AbortGroup>();
 
     if (options.actions) {
@@ -383,16 +402,17 @@ function makeAction(
         const previousSignal = (boundTo as { $signal?: AbortSignal }).$signal;
 
         const entry = asyncState[actionName];
-        entry.pending++;
-        entry.error = null;
-        if (controller) group.add(controller);
 
         const settle = (error?: unknown): void => {
-            entry.pending = Math.max(0, entry.pending - 1);
-            if (error !== undefined) {
-                entry.error =
-                    error instanceof Error ? error : new Error(String(error));
-            }
+            batchEffects(() => {
+                entry.pending = Math.max(0, entry.pending - 1);
+                if (error !== undefined) {
+                    entry.error =
+                        error instanceof Error
+                            ? error
+                            : new Error(String(error));
+                }
+            });
             if (controller) group.remove(controller);
         };
 
@@ -404,11 +424,29 @@ function makeAction(
                 writable: true,
             });
 
-            // Actions are the unit of change: batching means a multi-write
-            // action notifies subscribers once.
-            const result = batchEffects(() =>
-                actionFn.apply(boundTo, args),
-            ) as unknown;
+            // Actions are the unit of change: one batch spans the lifecycle
+            // bookkeeping *and* the action body, so subscribers wake once per
+            // call rather than once per field written. A synchronous action
+            // settles inside this same batch — its `pending` never being
+            // observable from outside is the point — while an async one
+            // returns at its first await, flushing a single "started"
+            // notification and settling later in its own batch.
+            const result = batchEffects(() => {
+                entry.pending++;
+                entry.error = null;
+                if (controller) group.add(controller);
+
+                let value: unknown;
+                try {
+                    value = actionFn.apply(boundTo, args);
+                } catch (error) {
+                    settle(error);
+                    throw error;
+                }
+
+                if (!isThenable(value)) settle();
+                return value;
+            }) as unknown;
 
             if (isThenable(result)) {
                 return result.then(
@@ -423,11 +461,7 @@ function makeAction(
                 );
             }
 
-            settle();
             return result;
-        } catch (error) {
-            settle(error);
-            throw error;
         } finally {
             Object.defineProperty(boundTo, '$signal', {
                 value: previousSignal,

--- a/packages/react/src/__tests__/async-lifecycle.test.tsx
+++ b/packages/react/src/__tests__/async-lifecycle.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * An async action's `pending`/`error` read off a `useQuanta`-resolved store.
+ *
+ * These live on a reactive object separate from `state`, so they only reach a
+ * component if the store's coarse change-notifier depends on them too. It
+ * previously did not: a raw `effect()` reading `pending` woke correctly, but
+ * `store.subscribe()` — and therefore `useQuanta` — never fired, which made a
+ * loading flag appear to work only when the action also happened to write
+ * state at around the same moment.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup, act } from '@testing-library/react';
+import { defineStore, destroyAllStores } from '@quantajs/core';
+import { useQuanta, useQuantaValue } from '../hooks/useStore';
+
+let uid = 0;
+const name = (p = 'async') => `${p}_${++uid}_${Date.now()}`;
+
+afterEach(() => {
+    cleanup();
+    destroyAllStores();
+});
+
+/** Deferred so the test controls exactly when the action settles. */
+function deferred<T = void>() {
+    let resolve!: (value: T) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+    return { promise, resolve, reject };
+}
+
+/**
+ * The action deliberately writes **no state** — the only thing a component
+ * could react to is the lifecycle flags themselves.
+ */
+const silentStore = (gate: Promise<void>) =>
+    defineStore(name('silent'), {
+        state: () => ({ untouched: 0 }),
+        actions: {
+            async save() {
+                await gate;
+            },
+        },
+    });
+
+describe('async action lifecycle in React', () => {
+    it('re-renders on pending via a useQuanta-resolved store', async () => {
+        const gate = deferred();
+        const definition = silentStore(gate.promise);
+
+        const Component = () => {
+            const store = useQuanta(definition);
+            return (
+                <button
+                    onClick={() => store.save()}
+                    disabled={store.save.pending}
+                >
+                    {store.save.pending ? 'Saving…' : 'Save'}
+                </button>
+            );
+        };
+
+        render(<Component />);
+        const button = screen.getByRole('button');
+        expect(button.textContent).toBe('Save');
+
+        await act(async () => {
+            button.click();
+        });
+        expect(button.textContent).toBe('Saving…');
+        expect((button as HTMLButtonElement).disabled).toBe(true);
+
+        await act(async () => {
+            gate.resolve();
+        });
+        expect(button.textContent).toBe('Save');
+        expect((button as HTMLButtonElement).disabled).toBe(false);
+    });
+
+    it('re-renders on error via a useQuanta-resolved store', async () => {
+        const gate = deferred();
+        const definition = silentStore(gate.promise);
+
+        const Component = () => {
+            const store = useQuanta(definition);
+            return (
+                <div>
+                    <button onClick={() => store.save().catch(() => {})}>
+                        Save
+                    </button>
+                    <span data-testid="err">
+                        {store.save.error?.message ?? 'none'}
+                    </span>
+                </div>
+            );
+        };
+
+        render(<Component />);
+        expect(screen.getByTestId('err').textContent).toBe('none');
+
+        await act(async () => {
+            screen.getByRole('button').click();
+        });
+        await act(async () => {
+            gate.reject(new Error('network down'));
+        });
+
+        expect(screen.getByTestId('err').textContent).toBe('network down');
+    });
+
+    it('re-renders on pending via a useQuantaValue selector', async () => {
+        // The narrower path — should work for the same reason, and did even
+        // before the notifier was wired up, since a selector tracks its own
+        // reads rather than relying on the store-wide channel.
+        const gate = deferred();
+        const definition = silentStore(gate.promise);
+
+        const Component = () => {
+            const pending = useQuantaValue(definition, (s) => s.save.pending);
+            const store = useQuanta(definition);
+            return (
+                <button onClick={() => store.save()}>
+                    {pending ? 'Saving…' : 'Save'}
+                </button>
+            );
+        };
+
+        render(<Component />);
+        const button = screen.getByRole('button');
+
+        await act(async () => {
+            button.click();
+        });
+        expect(button.textContent).toBe('Saving…');
+
+        await act(async () => {
+            gate.resolve();
+        });
+        expect(button.textContent).toBe('Save');
+    });
+
+    it('does not re-render a component for an unrelated action', async () => {
+        // The notifier now depends on every action's lifecycle entry, so this
+        // guards against that turning into a store-wide wake-up for any call.
+        const gate = deferred();
+        const definition = defineStore(name('two'), {
+            state: () => ({ n: 0 }),
+            actions: {
+                async watched() {
+                    await gate.promise;
+                },
+                async other() {
+                    await Promise.resolve();
+                },
+            },
+        });
+
+        let renders = 0;
+        const Component = () => {
+            const pending = useQuantaValue(
+                definition,
+                (s) => s.watched.pending,
+            );
+            renders++;
+            return <span>{String(pending)}</span>;
+        };
+
+        render(<Component />);
+        const baseline = renders;
+
+        await act(async () => {
+            await definition().other();
+        });
+        expect(renders).toBe(baseline);
+
+        gate.resolve();
+    });
+});


### PR DESCRIPTION
## Description

`pending` and `error` are reactive, but they live on a reactive object **separate** from `state`. The store's coarse change-notifier only enumerated `state`, so an effect watching the store never woke when a lifecycle flag flipped.

The symptom was worse than a plain "doesn't work": a raw `effect()` reading `store.save.pending` woke correctly, while `store.subscribe()` — and everything built on it, including React's `useQuanta` — missed it entirely, **except** when the action happened to also write state at around the same moment. So a loading spinner appeared to work in most stores and silently failed in the ones whose actions only call out to the network. Intermittently correct is the worst failure mode to ship.

This was flagged during the review of #96, where it was symptom-patched rather than fixed at the source.

### Root cause, confirmed before touching code

A probe test observed the same action through both channels:

- raw `effect()` → `[false, true, true, false, false]`
- `store.subscribe()` → `[]`

That isolates it: `asyncState` was reactive, it just was not wired into the notifier.

### The fix

`asyncState` moves above the deep-watcher effect, and the watcher now enumerates it alongside `state`. Enumerating also subscribes to the key set itself, so an action registered later — actions are wired up after this effect is created — re-runs the watcher and picks up its entry.

### A regression this caught on itself

Wiring the notifier up made a **synchronous** action emit 3 notifications instead of 1: the start bookkeeping, the action body, and `settle` were three separate batches. `makeAction`'s `invoke` is now restructured so one batch spans the lifecycle bookkeeping *and* the action body. A sync action settles inside that same batch; an async one returns at its first await, flushing a single "started" notification and settling later in its own batch.

One call therefore notifies subscribers once, not once per field written.

## Checklist
- [x] My code builds and runs correctly
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] I have added necessary documentation (if appropriate)

### Tests

`packages/core/src/__tests__/container.test.ts` — a `silentAction()` store whose action writes **no state**, so lifecycle flags are the only thing to react to:

- notifies on pending on/off
- notifies on rejection
- notifies once per transition, not once per field
- a state-only action still notifies exactly once (the guard that caught the 3× regression above)

`packages/react/src/__tests__/async-lifecycle.test.tsx` (new) — the same thing through React, with a deferred gate so the test controls exactly when the action settles:

- pending via `useQuanta`
- error via `useQuanta`
- pending via `useQuantaValue`
- one action's lifecycle does **not** wake a component watching a different action — the guard that the notifier's new dependency did not turn into a store-wide wake-up for every call

### Verification

- 400 tests passing (30 files)
- `pnpm lint` clean
- `pnpm build` clean
- `pnpm examples:build` and `pnpm examples:verify` passing

Documentation for this surface is in the companion quanta-docs PR (`guides/async-actions`), which follows the 2.1.0 release.

## Related Issues

Follow-up to #96.


---
_Generated by [Claude Code](https://claude.ai/code/session_01R8DNkp6NDU5AyLirroLhmC)_