### PR TITLE
perf(core): make the write path O(1) in state size

### DIFF
--- a/.changeset/perf-write-path.md
+++ b/.changeset/perf-write-path.md
@@ -1,0 +1,65 @@
+---
+'@quantajs/core': minor
+---
+
+Make the write path O(1) in the size of your state.
+
+A single `store.count++` on a store with 400 state keys cost **439
+microseconds**. The same write on a 5-key store cost 5.8µs — 76× the cost for
+80× the keys. Linear, in the operation an application performs most often. For
+scale, 439µs is about 3% of a 16ms frame budget for one property write.
+
+**Cause.** The store's coarse change-notifier was an effect whose body
+enumerated every state key so it would depend on all of them. An effect
+re-runs in order to re-register its dependencies, so every write re-read the
+entire store — each read paying a `WeakMap` lookup, a `Map` lookup and two
+`Set` inserts. `reactive()` itself was already O(1); the store was the problem.
+
+**Fix.** A per-object coarse channel (`ANY_CHANGE`) that `trigger` and
+`bubbleTrigger` notify alongside the per-key dependency. The notifier
+subscribes to exactly one dependency, and uses a `scheduler` so its body never
+re-runs — which is what removes the re-registration walk. It also fixes a
+latent gap: keys added after the store was created now notify without needing
+a re-enumeration.
+
+Alongside it, three constant-factor fixes on the same path:
+
+- **`Reflect.set(target, key, value, receiver)` re-enters the proxy's own
+  `getOwnPropertyDescriptor` and `defineProperty` traps** — 209ns against 21ns
+  for a direct assignment. The receiver only matters when an accessor must run
+  with `this` bound to the proxy, so objects with no accessors on themselves or
+  their prototype take the direct path. The check is made once per object and
+  cached.
+- **`bubbleTrigger` allocated a queue and two `Set`s on every nested write.**
+  Those exist for shared subtrees, which stay supported; a strictly linear
+  parent chain — virtually all application state — now walks with no
+  allocations at all.
+- **`notifyDependency` copied its subscriber set on every notification.** The
+  copy exists because subscribers re-register themselves mid-iteration, but
+  with exactly one subscriber there is nothing to iterate past. One dependency
+  with one subscriber is the common shape.
+
+**Measured** (median of warmed runs, ratios are the reliable part):
+
+| | 2.1.1 | 2.2.0 | |
+|---|---|---|---|
+| Store write · 5 keys | 5,765 ns | 200 ns | 29× |
+| Store write · 100 keys | 77,701 ns | 201 ns | 386× |
+| Store write · 400 keys | 438,805 ns | 184 ns | 2,385× |
+| Growth 5 → 400 keys | ×76 | ×0.92 | O(n) → O(1) |
+| Action dispatch · 400 keys | 470,496 ns | 2,420 ns | 194× |
+| Reactive write, no subscriber | 539 ns | 94 ns | 5.7× |
+| Nested write · depth 1 | 903 ns | 118 ns | 7.7× |
+| Nested write · depth 16 | 1,633 ns | 421 ns | 3.9× |
+
+Repository benchmarks: `write reactive property` 2.47×, `10k flat property
+writes` 3.10×, `store action dispatch` 1.77× on a small store.
+
+**No API change.** `ANY_CHANGE` is internal.
+
+Adds `write-path-complexity.test.ts`, which asserts the *structure* that makes
+the timing possible rather than the timing itself — a timing assertion cannot
+gate CI on shared runners. It checks that the notifier subscribes to exactly
+one dependency regardless of state size, that the dependency set does not grow
+as writes accumulate, that late-added keys still notify, and that the coarse
+channel is released on dispose. Verified to fail against the old notifier.

--- a/packages/core/src/__tests__/write-path-complexity.test.ts
+++ b/packages/core/src/__tests__/write-path-complexity.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Structural guards on the write path's complexity.
+ *
+ * A timing assertion cannot gate CI — shared runners are far too noisy — so
+ * these assert the *shape* that makes the timing possible instead. They are
+ * deterministic, and they fail the moment the O(n) they exist to prevent
+ * comes back.
+ *
+ * The regression they guard: the store's coarse change-notifier used to be an
+ * effect whose body enumerated every state key. Because an effect re-runs to
+ * re-register its dependencies, a single property write re-read the entire
+ * store — measured at 5.8us on a 5-key store and 439us on a 400-key one.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+    defineStore,
+    createContainer,
+    reactive,
+    effect,
+    toRaw,
+} from '../index';
+import { targetMap } from '../core/effect';
+import { ANY_CHANGE } from '../utils/deep-trigger';
+
+let containers: Array<ReturnType<typeof createContainer>> = [];
+const fresh = () => {
+    const c = createContainer();
+    containers.push(c);
+    return c;
+};
+
+afterEach(() => {
+    for (const c of containers) c.dispose();
+    containers = [];
+});
+
+/** How many distinct properties of `target` have subscribers. */
+function trackedPropertyCount(target: object): number {
+    const deps = targetMap.get(toRaw(target));
+    if (deps === undefined) return 0;
+    let live = 0;
+    for (const dep of deps.values()) if (dep.size > 0) live++;
+    return live;
+}
+
+const storeWith = (keyCount: number, name: string) => {
+    const initial: Record<string, number> = {};
+    for (let i = 0; i < keyCount; i++) initial['k' + i] = i;
+    return defineStore(name, {
+        state: () => ({ ...initial }),
+        actions: {
+            bump() {
+                (this as unknown as Record<string, number>).k0++;
+            },
+        },
+    })(fresh());
+};
+
+describe('write-path complexity', () => {
+    it('the store notifier subscribes to a constant number of dependencies', () => {
+        const small = storeWith(5, 'complexity_small');
+        const large = storeWith(500, 'complexity_large');
+
+        small.subscribe(() => {});
+        large.subscribe(() => {});
+
+        // One dependency — the coarse channel — regardless of state size. If
+        // this ever tracks the key count again, every write is O(state size).
+        expect(trackedPropertyCount(small.state)).toBe(1);
+        expect(trackedPropertyCount(large.state)).toBe(1);
+    });
+
+    it('subscribes via the coarse channel, not per key', () => {
+        const store = storeWith(20, 'complexity_channel');
+        store.subscribe(() => {});
+
+        const deps = targetMap.get(toRaw(store.state))!;
+        const live = [...deps.entries()].filter(([, dep]) => dep.size > 0);
+
+        expect(live).toHaveLength(1);
+        expect(live[0][0]).toBe(ANY_CHANGE);
+    });
+
+    it('does not grow its dependency set as writes accumulate', () => {
+        const store = storeWith(30, 'complexity_stable');
+        store.subscribe(() => {});
+
+        const before = trackedPropertyCount(store.state);
+        for (let i = 0; i < 200; i++) store.bump();
+        // A notifier that re-registered on every run would drift here; one
+        // that uses a scheduler never re-runs its body at all.
+        expect(trackedPropertyCount(store.state)).toBe(before);
+    });
+
+    it('still notifies for keys added after the store was created', () => {
+        const store = storeWith(3, 'complexity_latekey');
+        let notifications = 0;
+        store.subscribe(() => {
+            notifications++;
+        });
+
+        // The coarse channel fires for any key on the object, including one
+        // that did not exist when the notifier subscribed — which the old
+        // enumerate-every-key approach only handled by re-running.
+        (store.state as Record<string, unknown>).addedLater = 1;
+        expect(notifications).toBeGreaterThan(0);
+
+        const after = notifications;
+        (store.state as Record<string, unknown>).addedLater = 2;
+        expect(notifications).toBeGreaterThan(after);
+    });
+
+    it('releases the coarse channel when a store is disposed', () => {
+        // The gate in `trigger` is a counter of live coarse subscribers. If it
+        // only ever incremented, the lookup it guards would stay switched on
+        // for the rest of the process after the first store was created — the
+        // optimisation would work exactly once, which is the kind of thing
+        // that silently rots without a test.
+        const container = createContainer();
+        const store = defineStore('complexity_release', {
+            state: () => ({ a: 1 }),
+        })(container);
+        store.subscribe(() => {});
+
+        const raw = toRaw(store.state);
+        expect(targetMap.get(raw)?.get(ANY_CHANGE)?.size ?? 0).toBe(1);
+
+        container.dispose();
+
+        expect(targetMap.get(raw)?.get(ANY_CHANGE)?.size ?? 0).toBe(0);
+    });
+
+    it('a plain reactive object gains no coarse-channel overhead', () => {
+        // The ANY_CHANGE lookup on the write path is gated on some store
+        // actually using it, so a bare reactive object must not register one.
+        const plain = reactive({ a: 1, b: 2 });
+        effect(() => {
+            void plain.a;
+        });
+
+        const deps = targetMap.get(toRaw(plain));
+        expect(deps?.get(ANY_CHANGE)?.size ?? 0).toBe(0);
+    });
+});

--- a/packages/core/src/core/create-reactive.ts
+++ b/packages/core/src/core/create-reactive.ts
@@ -1,7 +1,14 @@
 import { track, trigger, batchEffects } from './effect';
 import { logger } from '../services/logger-service';
 import { __DEV__ } from '../utils/env';
-import { parentMap, setParent, removeParent } from '../utils/deep-trigger';
+import {
+    parentMap,
+    setParent,
+    removeParent,
+    ANY_CHANGE,
+} from '../utils/deep-trigger';
+
+export { ANY_CHANGE };
 import { devtools } from '../devtools';
 
 /** Retrieves the raw target behind a proxy. */
@@ -362,6 +369,51 @@ function createReactiveCollection(
 }
 
 /** Emit a DevTools event, never letting a listener break the mutation. */
+/**
+ * Objects known to hold only data properties, with a prototype that holds no
+ * accessors either.
+ *
+ * Computed once per object and cached, because the answer cannot change for
+ * the shapes that qualify: adding an accessor later goes through
+ * `defineProperty`, which is not a path the reactive proxy exposes, and a
+ * plain `x.foo = 1` write can only ever create a data property.
+ */
+const plainDataObjects = new WeakSet<object>();
+const nonPlainObjects = new WeakSet<object>();
+
+function isPlainDataObject(target: object): boolean {
+    if (plainDataObjects.has(target)) return true;
+    if (nonPlainObjects.has(target)) return false;
+
+    let plain = true;
+
+    // Own properties: any accessor disqualifies the object.
+    for (const key of Reflect.ownKeys(target)) {
+        const descriptor = Reflect.getOwnPropertyDescriptor(target, key);
+        if (descriptor !== undefined && !('value' in descriptor)) {
+            plain = false;
+            break;
+        }
+    }
+
+    // Prototype chain: an inherited setter is exactly the case the receiver
+    // argument exists for. `Object.prototype` and `Array.prototype` are
+    // treated as known-clean rather than walked on every new object.
+    if (plain) {
+        const proto = Object.getPrototypeOf(target);
+        if (
+            proto !== null &&
+            proto !== Object.prototype &&
+            proto !== Array.prototype
+        ) {
+            plain = false;
+        }
+    }
+
+    (plain ? plainDataObjects : nonPlainObjects).add(target);
+    return plain;
+}
+
 function notifyDevTools(
     target: object,
     prop: string | symbol | unknown,
@@ -485,8 +537,22 @@ export function createReactive<T>(target: T, flags: ReactiveFlags = DEEP): T {
                 removeParent(oldValue, source, prop);
             }
 
-            const result = Reflect.set(source, prop, rawValue, receiver);
-            if (!result) return false;
+            // `Reflect.set(..., receiver)` re-enters this proxy's
+            // getOwnPropertyDescriptor and defineProperty traps: measured at
+            // ~209ns/write against ~21ns for a direct assignment.
+            //
+            // The receiver only matters when an accessor runs and needs `this`
+            // bound to the proxy so that writes inside it stay tracked. For an
+            // object with no accessors anywhere on its prototype chain there is
+            // no accessor to run, and the direct write is observably identical.
+            // {@link isPlainDataObject} decides that once per object rather
+            // than paying for the check on every write.
+            if (hadKey && isPlainDataObject(source)) {
+                (source as Record<string | symbol, unknown>)[prop] = rawValue;
+            } else {
+                const result = Reflect.set(source, prop, rawValue, receiver);
+                if (!result) return false;
+            }
 
             if (typeof rawValue === 'object' && rawValue !== null) {
                 setParent(rawValue, source, prop);

--- a/packages/core/src/core/create-store.ts
+++ b/packages/core/src/core/create-store.ts
@@ -18,6 +18,7 @@ import {
     batchEffects,
     notifyDependency,
     effectScope,
+    track,
     type EffectScope,
 } from './effect';
 import { createPersistenceManager } from '../persistence';
@@ -29,7 +30,7 @@ import { logger } from '../services/logger-service';
 import { __DEV__ } from '../utils/env';
 import { devtools } from '../devtools';
 import { isSafeKey } from '../utils/sanitize';
-import { toRaw } from './create-reactive';
+import { toRaw, ANY_CHANGE } from './create-reactive';
 
 /** Hooks the owning container installs on a store. */
 export interface StoreHost {
@@ -88,33 +89,38 @@ export function instantiateStore<
     >({});
 
     scope.run(() => {
-        reactiveEffect(() => {
-            // Touch every top-level key so this effect depends on all of them;
-            // nested changes arrive by bubbling.
-            for (const key in state) {
-                void (state as Record<string, unknown>)[key];
-            }
-
-            // Same, for action lifecycle state. Enumerating also subscribes to
-            // the key set itself, so an action registered later (the actions
-            // are wired up after this effect is created) re-runs this and picks
-            // up its entry.
-            for (const key in asyncState) {
-                const entry = asyncState[key];
-                void entry.pending;
-                void entry.error;
-            }
-
-            // Subscriber callbacks routinely read reactive state. Without
-            // pausing, those reads are attributed to this effect and its
-            // dependency set grows on every notification.
-            const previous = pauseTracking();
-            try {
-                notifyDependency(dependency, []);
-            } finally {
-                resumeTracking(previous);
-            }
-        });
+        reactiveEffect(
+            () => {
+                // Subscribe once to each object's coarse channel instead of
+                // once per key. Reading ANY_CHANGE registers this effect
+                // against a single dependency that `trigger` notifies for any
+                // key on that object, so the cost of a write no longer grows
+                // with the number of state keys.
+                //
+                // Previously this body enumerated every state key and every
+                // action's lifecycle entry. Because an effect re-runs to
+                // re-register its dependencies, that made a single `count++`
+                // cost O(state size): measured at 5.7us on a 5-key store and
+                // 439us on a 400-key store, a 76x regression for 80x the keys.
+                trackAnyChange(state);
+                trackAnyChange(asyncState);
+            },
+            {
+                // The scheduler fires instead of the body, so dependencies are
+                // registered once and never re-registered. Subscriber
+                // callbacks routinely read reactive state, and running them
+                // outside a tracking context is what stops this effect's
+                // dependency set growing on every notification.
+                scheduler: () => {
+                    const previous = pauseTracking();
+                    try {
+                        notifyDependency(dependency, []);
+                    } finally {
+                        resumeTracking(previous);
+                    }
+                },
+            },
+        );
     });
 
     // ---- getters -----------------------------------------------------
@@ -330,6 +336,14 @@ export function instantiateStore<
     }
 
     return flattened;
+}
+
+/**
+ * Register the current effect against an object's coarse "anything changed"
+ * channel — one dependency for the whole object, regardless of its size.
+ */
+function trackAnyChange(target: object): void {
+    track(toRaw(target), ANY_CHANGE);
 }
 
 /* ------------------------------------------------------------------ *

--- a/packages/core/src/core/dependency.ts
+++ b/packages/core/src/core/dependency.ts
@@ -18,6 +18,16 @@ import type { EffectFunction } from '../type/store-types';
 export class Dependency {
     private subscribers: Set<EffectFunction> = new Set();
 
+    /**
+     * Whether this is an object's coarse ANY_CHANGE channel.
+     *
+     * `trigger` skips the coarse lookup entirely while no such channel has a
+     * subscriber, which requires knowing when one gains its first subscriber
+     * and loses its last. A `Dependency` does not otherwise know which key it
+     * belongs to, so the flag is set where it is created.
+     */
+    coarse = false;
+
     /** Subscribe a callback to this dependency. */
     depend(callback: EffectFunction | null | undefined): void {
         if (callback) this.subscribers.add(callback);

--- a/packages/core/src/core/effect.ts
+++ b/packages/core/src/core/effect.ts
@@ -62,7 +62,6 @@ export { targetMap };
  */
 let anyChangeSubscribers = 0;
 
-
 let activeEffect: EffectFunction | null = null;
 
 /**

--- a/packages/core/src/core/effect.ts
+++ b/packages/core/src/core/effect.ts
@@ -2,7 +2,7 @@ import { Dependency } from './dependency';
 import { logger } from '../services/logger-service';
 import { __DEV__ } from '../utils/env';
 import type { EffectFunction } from '../type/store-types';
-import { bubbleTrigger, parentMap } from '../utils/deep-trigger';
+import { bubbleTrigger, parentMap, ANY_CHANGE } from '../utils/deep-trigger';
 
 export interface EffectOptions {
     /** Custom scheduler invoked instead of the effect when dependencies change. */
@@ -51,6 +51,17 @@ export interface EffectRunner extends EffectFunction {
 /** target -> (property -> Dependency) */
 const targetMap = new WeakMap<object, Map<string | symbol, Dependency>>();
 export { targetMap };
+
+/**
+ * How many dependencies currently have a subscriber on their coarse channel.
+ *
+ * `trigger` runs on every write in the process, so the ANY_CHANGE lookup has
+ * to be free when nothing uses it. A plain `reactive()` object with no store
+ * attached never has an ANY_CHANGE subscriber, and an integer compare is
+ * cheaper than the Map.get it replaces.
+ */
+let anyChangeSubscribers = 0;
+
 
 let activeEffect: EffectFunction | null = null;
 
@@ -175,7 +186,22 @@ function scheduleEffect(effect: EffectFunction, errors: unknown[]): void {
  */
 export function notifyDependency(dep: Dependency, errors: unknown[]): void {
     const subscribers = dep.getSubscribers;
-    if (subscribers.size === 0) return;
+    const size = subscribers.size;
+    if (size === 0) return;
+
+    // The snapshot exists because a subscriber commonly removes and re-adds
+    // itself while running — that is how dependency re-tracking works — and
+    // mutating a Set during iteration loops forever per the ES specification.
+    //
+    // With exactly one subscriber there is nothing to iterate *past*, so the
+    // copy buys nothing and costs an array allocation on the hottest path in
+    // the library. One dependency with one subscriber is the overwhelmingly
+    // common shape: a component reading a field, a computed reading a source.
+    if (size === 1) {
+        const only = subscribers.values().next().value;
+        if (only !== undefined) scheduleEffect(only, errors);
+        return;
+    }
 
     for (const subscriber of [...subscribers]) {
         scheduleEffect(subscriber, errors);
@@ -189,6 +215,19 @@ export function notifyDependency(dep: Dependency, errors: unknown[]): void {
  * but it also should not prevent them from running — so errors are collected
  * during the pass and surfaced afterwards.
  */
+/**
+ * Unsubscribe an effect from a dependency, keeping the coarse-channel count
+ * accurate.
+ *
+ * Without the decrement the counter only grows, so the ANY_CHANGE lookup in
+ * `trigger` would stay switched on for the rest of the process after the first
+ * store was created — the optimisation would work exactly once.
+ */
+function releaseDep(dep: Dependency, effect: EffectFunction): void {
+    dep.remove(effect);
+    if (dep.coarse && dep.size === 0) anyChangeSubscribers--;
+}
+
 function settleErrors(errors: unknown[]): void {
     if (errors.length === 0) return;
 
@@ -317,19 +356,36 @@ export function nextTick(fn?: () => void): Promise<void> {
  * every depth.
  */
 export function trigger(target: object, prop: string | symbol): void {
+    // Deliberately still allocated per call. Making it lazy measures at ~6ns
+    // and requires either a shared array that `scheduleEffect` would mutate
+    // across re-entrant triggers, or a module-level sink that must be saved
+    // and restored — both of which risk surfacing an error at the wrong time.
+    // Not worth 6ns.
     const errors: unknown[] = [];
 
     const depsMap = targetMap.get(target);
     if (depsMap !== undefined) {
         const dep = depsMap.get(prop);
         if (dep !== undefined) notifyDependency(dep, errors);
+
+        // The coarse channel: one dependency per object rather than one per
+        // key, which is what replaced the store's O(state-size) enumeration.
+        // Skipped entirely when nothing subscribes to it anywhere, so a bare
+        // `reactive()` write pays an integer compare instead of a Map lookup.
+        if (anyChangeSubscribers > 0) {
+            const anyDep = depsMap.get(ANY_CHANGE);
+            if (anyDep !== undefined) notifyDependency(anyDep, errors);
+        }
     }
 
     // Only walk upwards when this object is actually attached to a parent;
     // root-level state has no parents and this check keeps the common case free.
     if (parentMap.has(target)) {
-        bubbleTrigger(target, targetMap, (dep) =>
-            notifyDependency(dep, errors),
+        bubbleTrigger(
+            target,
+            targetMap,
+            (dep) => notifyDependency(dep, errors),
+            anyChangeSubscribers > 0,
         );
     }
 
@@ -362,6 +418,10 @@ export function track(target: object, prop: string | symbol): void {
         depsMap.set(prop, dep);
     }
 
+    if (prop === ANY_CHANGE) {
+        dep.coarse = true;
+        if (dep.size === 0) anyChangeSubscribers++;
+    }
     dep.depend(activeEffect);
 
     // Record the dep on the effect so a later re-run can unsubscribe from it.
@@ -409,7 +469,7 @@ export function reactiveEffect(
 
         // Drop stale subscriptions before re-tracking. Without this an effect
         // whose dependencies change over time accumulates subscribers forever.
-        for (const dep of deps) dep.remove(wrappedEffect);
+        for (const dep of deps) releaseDep(dep, wrappedEffect);
         deps.clear();
 
         effectStack.push(wrappedEffect);
@@ -432,7 +492,7 @@ export function reactiveEffect(
     wrappedEffect.stop = () => {
         if (!wrappedEffect.active) return;
         wrappedEffect.active = false;
-        for (const dep of deps) dep.remove(wrappedEffect);
+        for (const dep of deps) releaseDep(dep, wrappedEffect);
         deps.clear();
         effectDeps.delete(wrappedEffect);
         effectQueue.delete(wrappedEffect);

--- a/packages/core/src/utils/deep-trigger.ts
+++ b/packages/core/src/utils/deep-trigger.ts
@@ -23,6 +23,30 @@ import type { Dependency } from '../core/dependency';
  */
 const parentMap = new WeakMap<object, Map<object, Set<string | symbol>>>();
 
+/**
+ * A per-object "something in here changed" channel.
+ *
+ * Subscribing to it costs one dependency for the whole object and stays O(1)
+ * as the object grows, where subscribing per key costs one dependency per key
+ * *and* re-registers every one of them on each notification.
+ *
+ * Declared in this module rather than beside `ITERATE_KEY` because both
+ * `effect.ts` and `create-reactive.ts` need it, and this is the only one of
+ * the three with no imports from the other two — putting it anywhere else
+ * closes an import cycle.
+ */
+export const ANY_CHANGE = Symbol('quanta.any');
+
+/**
+ * How far the allocation-free linear walk will go before handing over to the
+ * full graph walk.
+ *
+ * Without a visited set the fast path cannot detect a cycle, so it is bounded
+ * instead. State nested deeper than this is rare enough that the extra
+ * allocations do not matter.
+ */
+const LINEAR_FAST_PATH_MAX_DEPTH = 32;
+
 export { parentMap };
 
 /**
@@ -99,13 +123,46 @@ export function bubbleTrigger(
     target: object,
     targetMap: WeakMap<object, Map<string | symbol, Dependency>>,
     notify: (dep: Dependency) => void,
+    notifyAnyChange = false,
 ): void {
     try {
+        // Fast path: a strictly linear chain — every node has exactly one
+        // parent holding it at exactly one key. That is the shape of virtually
+        // all application state, and it needs no queue, no visited set and no
+        // dedupe set, because a linear walk cannot revisit a node or reach the
+        // same dependency twice.
+        //
+        // The full graph walk below exists for shared subtrees, which are
+        // legal and must stay correct; this just stops every ordinary nested
+        // write paying for machinery only they need. The depth cap is a cycle
+        // guard: without a visited set, a cycle would spin here forever.
+        let node: object = target;
+        for (let depth = 0; depth < LINEAR_FAST_PATH_MAX_DEPTH; depth++) {
+            const parents = parentMap.get(node);
+            if (parents === undefined || parents.size === 0) return; // done
+            if (parents.size > 1) break; // branching — fall back
+
+            const [parent, keys] = parents.entries().next().value!;
+            if (keys.size > 1) break; // one object at several keys — fall back
+
+            const parentDeps = targetMap.get(parent);
+            if (parentDeps !== undefined) {
+                if (notifyAnyChange) {
+                    const anyDep = parentDeps.get(ANY_CHANGE);
+                    if (anyDep !== undefined) notify(anyDep);
+                }
+                const key = keys.values().next().value!;
+                const dep = parentDeps.get(key);
+                if (dep !== undefined) notify(dep);
+            }
+            node = parent;
+        }
+
         // Breadth-first over the ancestor DAG. An object can sit at several
         // paths at once (shared instances), so this is a graph walk, not a
         // simple parent chain.
-        const queue: object[] = [target];
-        const visited = new Set<object>([target]);
+        const queue: object[] = [node];
+        const visited = new Set<object>([node]);
 
         // A single Dependency can be reachable through several edges — a
         // diamond in the ownership graph, or one object stored at two keys of
@@ -124,6 +181,15 @@ export function bubbleTrigger(
             for (const [parent, keys] of parents) {
                 const parentDeps = targetMap.get(parent);
                 if (parentDeps !== undefined) {
+                    // Coarse channel for this ancestor, so a subscriber to the
+                    // whole subtree costs one dependency instead of one per key.
+                    if (notifyAnyChange) {
+                        const anyDep = parentDeps.get(ANY_CHANGE);
+                        if (anyDep !== undefined && !notified.has(anyDep)) {
+                            notified.add(anyDep);
+                            notify(anyDep);
+                        }
+                    }
                     for (const key of keys) {
                         const dep = parentDeps.get(key);
                         if (dep !== undefined && !notified.has(dep)) {


### PR DESCRIPTION
## Description

A single `store.count++` on a store with **400 state keys cost 439 microseconds**. The same write on a 5-key store cost 5.8µs — 76× the cost for 80× the keys.

Linear, in the operation an application performs most often. For scale, 439µs is roughly 3% of a 16ms frame budget, for one property write. This is the thing that stops QuantaJS being what it says it is.

### How it was found

The existing benchmarks measure throughput on small fixtures, which answers "is the constant factor good" but not "does it scale". I wrote probes that vary one dimension at a time and look at the *shape* of the curve — a flat curve is O(1) in that dimension, a curve tracking the input is O(n) and no constant factor rescues it.

### Cause

The store's coarse change-notifier was an effect whose body enumerated every state key so it would depend on all of them:

```ts
reactiveEffect(() => {
    for (const key in state) void state[key];   // O(keys)
    for (const key in asyncState) { … }
    notifyDependency(dependency, []);
});
```

An effect re-runs *in order to re-register its dependencies*, so every write re-read the whole store — each read paying a `WeakMap` lookup, a `Map` lookup and two `Set` inserts. `reactive()` itself was already flat at 5, 100 and 400 keys; the store was the problem.

### Fix

A per-object coarse channel (`ANY_CHANGE`) that `trigger` and `bubbleTrigger` notify alongside the per-key dependency. The notifier subscribes to exactly one dependency and uses a `scheduler`, so its body never re-runs — which is what removes the re-registration walk.

It also closes a latent gap: keys added after the store was created now notify without needing a re-enumeration to pick them up.

### Three constant-factor fixes on the same path

- **`Reflect.set(target, key, value, receiver)` re-enters the proxy's own `getOwnPropertyDescriptor` and `defineProperty` traps** — 209ns against 21ns for a direct assignment. The receiver only matters when an accessor must run with `this` bound to the proxy; objects with no accessors on themselves or their prototype take the direct path, decided once per object and cached.
- **`bubbleTrigger` allocated a queue and two `Set`s on every nested write.** Those exist for shared subtrees, which stay fully supported; a strictly linear parent chain — virtually all application state — now walks with no allocations.
- **`notifyDependency` copied its subscriber set on every notification.** The copy exists because subscribers re-register mid-iteration, but with exactly one subscriber there is nothing to iterate past.

## Measured

| | 2.1.1 | This PR | |
|---|---|---|---|
| Store write · 5 keys | 5,765 ns | 200 ns | **29×** |
| Store write · 100 keys | 77,701 ns | 201 ns | **386×** |
| Store write · 400 keys | 438,805 ns | 184 ns | **2,385×** |
| **Growth 5 → 400 keys** | **×76** | **×0.92** | **O(n) → O(1)** |
| Action dispatch · 400 keys | 470,496 ns | 2,420 ns | 194× |
| Reactive write, no subscriber | 539 ns | 94 ns | 5.7× |
| Nested write · depth 1 | 903 ns | 118 ns | 7.7× |
| Nested write · depth 16 | 1,633 ns | 421 ns | 3.9× |

Repository benchmarks: `write reactive property` **2.47×**, `10k flat property writes` **3.10×**, `store action dispatch` **1.77×** on a small store.

## Checklist
- [x] My code builds and runs correctly
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] I have added necessary documentation (if appropriate)

## Two things investigated and deliberately not changed

<details>
<summary><strong>The "1k subscribers" benchmark reading ~20% lower</strong></summary>

I flagged this as a possible regression and chased it. It is **not** a subscriber benchmark — it builds 1000 `computed`s fanning out from one `reactive` value and re-reads them each iteration.

Measured over 15 trials rather than one sample: **32.8ms vs 31.3ms**, with heavily overlapping ranges (28.9–37.1 against 27.4–37.8). There is also no mechanism — nothing here touches the computed read path.

Real store subscribers, measured the same way, are **1.7× faster**: 1000 subscribers × 1000 updates goes 20.4ms → 13.4ms.

Conclusion: noise in a single sample, not a regression.
</details>

<details>
<summary><strong>The <code>errors: []</code> allocation in <code>trigger</code></strong></summary>

Measured at ~6ns per write. Removing it needs either a shared array that `scheduleEffect` would mutate across re-entrant triggers, or a module-level sink saved and restored around each call. Both risk surfacing an error at the wrong time. Not worth 6ns — I tried it, then reverted it.
</details>

## Still open

Nested reads cost ~115ns per level because `setParent` and the proxy cache each perform a `WeakMap.get` on the same object. Merging those into one record would save a lookup per level, but it is a restructure and belongs in its own change rather than riding along here.

## Regression guard

`write-path-complexity.test.ts` asserts the **structure** that makes the timing possible, not the timing — a timing assertion cannot gate CI on shared runners. It checks that the notifier subscribes to exactly one dependency regardless of state size, that its dependency set does not grow as writes accumulate, that late-added keys still notify, that a bare `reactive()` object gains no coarse-channel overhead, and that the channel is released on dispose.

I verified it fails against the old notifier by putting the enumerate-every-key version back: 2 of the 5 guards fail.

## Verification

- 410 tests passing (32 files)
- `pnpm lint`, `pnpm -r test:types`, `pnpm build` clean
- `pnpm examples:build` and `pnpm examples:verify` passing
- `pnpm verify:packaging` passing
- Accessor semantics verified separately — own setters, inherited setters, class instances, arrays, new keys and nested bubbling all behave as before

## Note on ordering

This lands before the patch stream on purpose. The patch emitter adds work to the write path, so optimising afterwards means optimising *around* a feature instead of underneath it — and `ANY_CHANGE` is the primitive the emitter wants to subscribe to anyway.

No API change; `ANY_CHANGE` is internal.


---
_Generated by [Claude Code](https://claude.ai/code/session_01R8DNkp6NDU5AyLirroLhmC)_