### PR TITLE
perf(core): check the reactive cache before the guards it makes redundant

### DIFF
--- a/.changeset/perf-read-path.md
+++ b/.changeset/perf-read-path.md
@@ -1,0 +1,29 @@
+---
+'@quantajs/core': patch
+---
+
+Cut ~19% from nested property reads by consulting the reactive proxy cache
+before the guards that a cache hit has already proven unnecessary.
+
+Every nested read reaches `createReactive`, and almost all of them are cache
+hits — the proxy for `state.user` is built once and returned on every
+subsequent read. The cache lookup was last, behind `isNonReactiveBuiltin`
+(nine checks, eight of them `instanceof`) and a `WeakSet.has`. A cached proxy
+can only exist because a previous call ran those same guards and passed, so
+every hit paid for a question already answered.
+
+Measured on a cache hit: guards-then-lookup 30.5ns, lookup-first 5.4ns.
+
+| Read | Before | After |
+|---|---|---|
+| depth 1 | 100.6 ns | 81.7 ns |
+| depth 2 | 211.9 ns | 178.5 ns |
+| depth 3 | 308.0 ns | 242.0 ns |
+| depth 4 | 349.3 ns | 286.9 ns |
+
+`markRaw` deliberately stays in front of the cache — it can be applied to an
+object that is already reactive and must still win — and costs 0.6ns there.
+The remaining guards run on a miss, which is once per object rather than once
+per read.
+
+No API change, no new data structures.

--- a/packages/core/src/__tests__/api-surface.test.ts
+++ b/packages/core/src/__tests__/api-surface.test.ts
@@ -475,3 +475,48 @@ describe('composition', () => {
         expect(calls).toBe(2);
     });
 });
+
+/**
+ * `createReactive` consults its proxy cache *before* the builtin and
+ * already-a-proxy guards, because a cached proxy can only exist if a previous
+ * call already ran and passed those guards. `markRaw` deliberately stays in
+ * front of the cache: it can be applied to an object that has already been
+ * made reactive, and it must still win.
+ */
+describe('reactive cache/guard ordering', () => {
+    it('returns the identical proxy for repeat reads of a nested object', () => {
+        const state = reactive({ nested: { deep: { v: 1 } } });
+        expect(state.nested).toBe(state.nested);
+        expect(state.nested.deep).toBe(state.nested.deep);
+    });
+
+    it('still refuses to wrap builtins that have no cache entry', () => {
+        const date = new Date();
+        const state = reactive({
+            when: date,
+            re: /x/,
+            buf: new ArrayBuffer(8),
+        });
+        expect(toRaw(state.when)).toBe(date);
+        expect(isReactive(state.when)).toBe(false);
+        expect(isReactive(state.re)).toBe(false);
+        expect(isReactive(state.buf)).toBe(false);
+    });
+
+    it('never double-wraps an existing proxy', () => {
+        const inner = reactive({ a: 1 });
+        expect(reactive(inner)).toBe(inner);
+    });
+
+    it('markRaw wins even when applied after the proxy was cached', () => {
+        const heavy = { big: true };
+        const state = reactive({ heavy });
+        expect(isReactive(state.heavy)).toBe(true); // cached proxy exists
+
+        markRaw(heavy);
+
+        // markRaw is checked ahead of the cache, so it takes effect for reads
+        // made after the mark rather than being shadowed by the cache hit.
+        expect(reactive(heavy)).toBe(heavy);
+    });
+});

--- a/packages/core/src/core/create-reactive.ts
+++ b/packages/core/src/core/create-reactive.ts
@@ -441,19 +441,39 @@ export function createReactive<T>(target: T, flags: ReactiveFlags = DEEP): T {
 
     const obj = target as unknown as object;
 
-    if (isNonReactiveBuiltin(obj) || isMarkedRaw(obj)) return target;
-
-    // Never wrap a proxy in another proxy: spreading a reactive array
-    // (`[...items]`) would otherwise chain traps exponentially.
-    if (proxySet.has(obj)) return target;
+    // `markRaw` stays in front of the cache: it can be applied to an object
+    // that was already made reactive, and it must win when it is. At ~0.6ns
+    // for a symbol property read it costs nothing to keep here.
+    if (isMarkedRaw(obj)) return target;
 
     const cache = flags.readonly
         ? readonlyMap
         : flags.shallow
           ? shallowMap
           : reactiveMap;
+
+    // Cache first.
+    //
+    // Every nested property read reaches this function, and the overwhelming
+    // majority are cache hits — the proxy for `state.user` is built once and
+    // returned on every subsequent read of it. Running the guards ahead of the
+    // lookup meant each of those hits paid for checks whose answer was already
+    // settled: a cached proxy exists only because a previous call ran the very
+    // same guards and passed them.
+    //
+    // Measured on a cache hit: guards-then-lookup 30.5ns, lookup-first 5.4ns,
+    // against ~105ns for a whole nested read. The guards below still run on a
+    // miss, which is once per object rather than once per read.
     const cached = cache.get(obj);
     if (cached) return cached as unknown as T;
+
+    if (isNonReactiveBuiltin(obj)) return target;
+
+    // Never wrap a proxy in another proxy: spreading a reactive array
+    // (`[...items]`) would otherwise chain traps exponentially. A proxy is
+    // never a cache key — only raw targets are — so this cannot be reached
+    // through a hit above.
+    if (proxySet.has(obj)) return target;
 
     if (obj instanceof Map || obj instanceof Set) {
         return createReactiveCollection(


### PR DESCRIPTION
## Description

You asked me to prove the read-path optimisation was worth doing before starting it. **It was worth doing — but not the one I proposed.** I was wrong about both the cause and the size, and the analysis is below.

### What I claimed, and what is actually true

> "Nested reads cost ~115ns per level because `setParent` and the proxy cache each do a `WeakMap.get` on the same object. Merging those records is probably worth another 2× on deep reads."

Wrong on the size, and wrong about where the cost sits. Measured per component on a cache hit:

| Component | Cost |
|---|---|
| `isNonReactiveBuiltin` (9 checks, 8 × `instanceof`) | 14.1 ns |
| `setParent` (edge already present) | 18.6 ns |
| `WeakMap.get` (cache hit) | 6.0 ns |
| `WeakSet.has` (proxy check) | 5.5 ns |
| `isMarkedRaw` (symbol read) | 0.6 ns |

The double `WeakMap.get` I fixated on is **6ns**. The real cost was the *order*: the cache lookup ran **last**, behind all the guards. A cached proxy can only exist because a previous call ran those same guards and passed, so every hit paid for a question already answered.

Guards-then-lookup **30.5ns** → lookup-first **5.4ns**.

## The fix

Move the cache lookup ahead of `isNonReactiveBuiltin` and the `proxySet` check. `markRaw` stays in front — it can be applied to an object that is already reactive and must still win — and costs 0.6ns there.

| Read | Before | After | |
|---|---|---|---|
| depth 1 | 100.6 ns | 81.7 ns | **19%** |
| depth 2 | 211.9 ns | 178.5 ns | 16% |
| depth 3 | 308.0 ns | 242.0 ns | 21% |
| depth 4 | 349.3 ns | 286.9 ns | 18% |

No API change, no new data structures, and the ordering now reads more naturally — cheapest check first.

## Checklist
- [x] My code builds and runs correctly
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] I have added necessary documentation (if appropriate)

## What I deliberately did **not** do, and why

I bounded the whole `parentMap` optimisation family by deleting `setParent` outright — which breaks deep reactivity, but establishes the ceiling no such change could ever beat:

| depth | with `setParent` | `setParent` removed | ceiling |
|---|---|---|---|
| 1 | 81.7 ns | 57.7 ns | 29% |
| 2 | 178.5 ns | 115.6 ns | 35% |
| 3 | 242.0 ns | 175.4 ns | 28% |

A realistic single-edge fast path recovers maybe half of that — **~10ns, about 12%** — because the `WeakMap.get` still has to happen. Merging `parentMap` into the proxy cache record recovers the **6ns** measured above.

The cost is not small: `parentMap` is read by `setParent`, `removeParent`, `bubbleTrigger` and `getParentChain`. A dual-shape representation means two code paths in each, permanently, in the module whose own comments record that stale edges previously caused *two distinct bugs* — phantom invalidations and retained subtrees.

**12% for permanent complexity in the subtlest module is the wrong trade**, and against "simplicity is a core principle" it is not close.

<details>
<summary>I also re-tested the <code>Reflect</code> receiver trick that gave 10× on writes</summary>

It does not transfer. For reads the receiver costs ~2ns, because `Reflect.get` does not re-enter `getOwnPropertyDescriptor`/`defineProperty` the way `Reflect.set` does:

| | |
|---|---|
| `Reflect.get(t, p, receiver)` | 30.8 ns |
| `Reflect.get(t, p)` | 28.6 ns |
| `t[p]` direct | 22.8 ns |

The receiver is also load-bearing for inherited getters — it is what binds `this` to the proxy so reads inside a getter stay tracked. Not worth 8ns.
</details>

## Where the read path now stands

Roughly 82ns per nested level, of which:

- **~30 ns** — Proxy trap entry and `Reflect.get`. Irreducible; this is what a `Proxy` costs in V8.
- **~24 ns** — `setParent`. The price of deep reactivity working at all.
- **~6 ns** — cache lookup.
- **~20 ns** — type checks, the array-mutator guard, call overhead.

Nothing large is left. After this, the read path is close to the floor for a Proxy-based design, and further work there would buy single-digit percentages for real complexity.

## Verification

- 414 tests passing (4 new ordering-invariant tests: identical proxy on repeat reads, builtins still refused, no double-wrapping, `markRaw` after caching still wins)
- `lint`, `test:types`, `build`, `test`, `verify-packaging`, `examples:build`, `examples:verify` — all exit 0
- Accessor semantics probes pass
- Write-path measurements unchanged, confirming this touches reads only


---
_Generated by [Claude Code](https://claude.ai/code/session_01R8DNkp6NDU5AyLirroLhmC)_